### PR TITLE
Add calculating ambient occlusion to the calclight routine

### DIFF
--- a/src/engine/lightmap.h
+++ b/src/engine/lightmap.h
@@ -1,15 +1,23 @@
 #define LM_MINW 2
 #define LM_MINH 2
 #define LM_MAXW 128
-#define LM_MAXH 128
-#define LM_PACKW 512
+#define LM_MAXH 128  //min and maximum dimensions of one lightmap-sample (the smaller the samples the bigger the resolution)
+#define LM_PACKW 512 //size of one packed and saved lightmap
 #define LM_PACKH 512
 
+//a helper node to save more lightmaps on a lightmaptexture
+//it basicly just containes its position on the lmtex (x, y) , the area it contains (w,h) and how much unused pixels in this area are
+//structure is as follows: 
+//                          rootnode (every lightmaptex has one)
+//           child1                       child2
+//    child1a      child1b         child2a       child2b 
+//       ...
+//
 struct PackNode
 {
     PackNode *child1, *child2;
     ushort x, y, w, h;
-    int available;
+    int available; //amount of pixels without lightmap-information
 
     PackNode() : child1(0), child2(0), x(0), y(0), w(LM_PACKW), h(LM_PACKH), available(min(LM_PACKW, LM_PACKH)) {}
     PackNode(ushort x, ushort y, ushort w, ushort h) : child1(0), child2(0), x(x), y(y), w(w), h(h), available(min(w, h)) {}
@@ -42,9 +50,9 @@ enum
 struct LightMap
 {
     int type, bpp, tex, offsetx, offsety;
-    PackNode packroot;
-    uint lightmaps, lumels;
-    int unlitx, unlity; 
+    PackNode packroot;		//the availability-information-tree
+    uint lightmaps, lumels; //lumel = lightmap pixel
+    int unlitx, unlity;		//one unlit lumel
     uchar *data;
 
     LightMap()

--- a/src/engine/octaedit.cpp
+++ b/src/engine/octaedit.cpp
@@ -2038,7 +2038,7 @@ void gettex()
         return;
     }
 }
-
+//receive current texture index
 void getcurtex()
 {
     if(noedit(true)) return;
@@ -2047,7 +2047,7 @@ void getcurtex()
     if(!texmru.inrange(index)) return;
     intret(texmru[index]);
 }
-
+//receive tex id of selected face
 void getseltex()
 {
     if(noedit(true)) return;
@@ -2055,7 +2055,7 @@ void getseltex()
     if(c.children || isempty(c)) return;
     intret(c.texture[sel.orient]);
 }
-
+//receive the namestring of a tex id. (subslot is which subtexture, default is diffuse. others may be bumpmap, depthmap, specmap..)
 void gettexname(int *tex, int *subslot)
 {
     if(noedit(true) || *tex<0) return;


### PR DESCRIPTION
you have 2 new mapoptions:
ambientocclusion (value between 0 for off and 255 for very dark)
ambientocclusionradius (radius of the shadow)

a more detailed explanation taken from the source: 

> ambient occlusion (darkening of corners) works as follows:
you check for every point how much light possible comes onto it when the light comes from the whole sky (no lights/spotlights, whatever)
this will darken cracks and sharp edges and hence give a more realistic rendering output.
from every point we send out ray casts into the main directions (see below) and get a hit back if it touched the sky (or a skytextured cube, see RAY_SKIPSKY)
we then darken the lightmap color depending on how much the pixel is occlued. 
(rays-hitting-a-wall / total-rays-sent -> value between 0 and 1.0) 1.0 = totally occlued, 0.0 = no occlusion


**furthermore see https://github.com/inexor-game/code/wiki/Ambient-Occlusion**
**it has images**


what does still need to be done?
nothing, it can be merged. (I may make some really small adjustments afterwards though)