### PR TITLE
Make crosshairdir relative to the interfacedir

### DIFF
--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -2258,17 +2258,20 @@ VARP(cursorsize, 0, 30, 50);
 VARP(crosshairfx, 0, 1, 1);
 VARP(crosshaircolors, 0, 1, 1);
 
+// Directory where crosshairs are stored.
+SVARP(crosshairdir, "media/interface/crosshair");
+
 #define MAXCROSSHAIRS 4
 static Texture *crosshairs[MAXCROSSHAIRS] = { NULL, NULL, NULL, NULL };
 
 void loadcrosshair(const char *name, int i)
 {
     if(i < 0 || i >= MAXCROSSHAIRS) return;
-	crosshairs[i] = name ? textureload(name, 3, true) : notexture;
-    if(crosshairs[i] == notexture) 
+    crosshairs[i] = name ? textureload(tempformatstring("%s/%s", crosshairdir, name), 3, true) : notexture;
+    if(!crosshairs[i] || crosshairs[i] == notexture) 
     {
         name = game::defaultcrosshair(i);
-        crosshairs[i] = textureload(name, 3, true);
+        crosshairs[i] = textureload(tempformatstring("%s/%s", crosshairdir, name), 3, true);
     }
 }
 
@@ -2291,8 +2294,15 @@ ICOMMAND(getcrosshair, "i", (int *i),
  
 void writecrosshairs(stream *f)
 {
-    loopi(MAXCROSSHAIRS) if(crosshairs[i] && crosshairs[i]!=notexture)
+    loopi(MAXCROSSHAIRS) if(crosshairs[i] && crosshairs[i] != notexture)
+    {
+        size_t len = strlen(crosshairdir);
+        if(!strncmp(crosshairs[i]->name, path(crosshairdir), len))
+        {
+            crosshairs[i]->name += len+1;
+        }
         f->printf("loadcrosshair %s %d\n", escapestring(crosshairs[i]->name), i);
+    }
     f->printf("\n");
 }
 

--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -1107,19 +1107,15 @@ namespace game
 	/// displaying a hit crosshair increases the players hit impression ('feel')
     VARP(hitcrosshair, 0, 425, 1000);
 
-    /// Directory where crosshairs are stored. Relative to interfacedir
-    SVARP(crosshairdir, "crosshair");
-
-	/// crosshair file names are stored in a constant functions
-	/// that return strings depending on indices
-    /// TODO: remove this hardcoded passage and move on to JSON!
+	// crosshair file names are stored in a constant functions
+	// that return strings depending on indices
     const char *defaultcrosshair(int index)
     {
         switch(index)
         {
-            case 2: return tempformatstring("%s/default_hit.png", crosshairdir);
-            case 1: return tempformatstring("%s/default_teammate.png", crosshairdir);
-            default: return tempformatstring("%s/default.png", crosshairdir);
+            case 2: return "default_hit.png";
+            case 1: return "default_teammate.png";
+            default: return "default.png";
         }
     }
 


### PR DESCRIPTION
As it was meant.
Unfortunately, I can't compile on my own due to #121. But this should fix it, that via default the crosshair is missing.