### PR TITLE
Hanni/fixes

### DIFF
--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -338,7 +338,7 @@ namespace game
                 }
             }
             /// fix: allow spectators to fly around during intermission!
-            else if(!intermission || player1->state == CS_SPECTATOR)
+            else if (!intermission || (intermission && player1->state == CS_SPECTATOR))
             {
                 if(player1->ragdoll) cleanragdoll(player1);
                 moveplayer(player1, 10, true);
@@ -584,11 +584,12 @@ namespace game
         }
     }
 
-    void test_test()
+    /// force intermission to test free camera fly
+    void test_intermission()
     {
         timeupdate(0);
     }
-    COMMAND(test_test, "");
+    COMMAND(test_intermission, "");
 
     /// return a player's statistics to cubescript
     ICOMMAND(getfrags, "", (), intret(player1->frags));

--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -337,7 +337,8 @@ namespace game
                     moveplayer(player1, 10, true);
                 }
             }
-            else if(!intermission)
+            /// fix: allow spectators to fly around during intermission!
+            else if(!intermission || player1->state == CS_SPECTATOR)
             {
                 if(player1->ragdoll) cleanragdoll(player1);
                 moveplayer(player1, 10, true);
@@ -551,6 +552,9 @@ namespace game
         if(cmode) cmode->killed(d, actor);
     }
 
+
+
+
     /// update game session time
     /// display intermission statistics in console
     void timeupdate(int secs)
@@ -579,6 +583,12 @@ namespace game
             if(identexists("intermission")) execute("intermission");
         }
     }
+
+    void test_test()
+    {
+        timeupdate(0);
+    }
+    COMMAND(test_test, "");
 
     /// return a player's statistics to cubescript
     ICOMMAND(getfrags, "", (), intret(player1->frags));

--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -584,13 +584,6 @@ namespace game
         }
     }
 
-    /// force intermission to test free camera fly
-    void test_intermission()
-    {
-        timeupdate(0);
-    }
-    COMMAND(test_intermission, "");
-
     /// return a player's statistics to cubescript
     ICOMMAND(getfrags, "", (), intret(player1->frags));
     ICOMMAND(getflags, "", (), intret(player1->flags));


### PR DESCRIPTION
There is no reason why spectators should have fixed cameras during intermission.
I tested this simple feature on many multiplayer servers and in singleplayer.