### PR TITLE
JSON API updates

### DIFF
--- a/src/shared/cube.h
+++ b/src/shared/cube.h
@@ -86,13 +86,13 @@
 /// command line and scripting engine
 #include "command.h"
 
+/// JSON (Javascript Object Notation) parser
+/// Static data storage format
+#include "json.h"
+
 /// header files for communication between the game and Cube engine
 #include "iengine.h"
 #include "igame.h"
-
-/// JSON (Javascript Object Notation) parser
-/// http://json.org/
-#include "json.h"
 
 
 #endif /// end include guard __CUBE_H__

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -1,5 +1,8 @@
-//  Rewrite of cJSON 1.0r58 in Inexor-optimized object-orientated C-ish C++
-//  cJSON (Copyright (c) 2009 by Dave Gamble) is licensed under the MIT-license
+///  JSON is used to store data-information
+///  Rewrite of cJSON 1.0r58 in Inexor-optimized object-orientated C-ish C++
+///  Author: Malte "a_teammate" Haase
+///  Created:   31.12.2014
+///  cJSON (Copyright (c) 2009 by Dave Gamble) is licensed under the MIT-license
 
 #include "engine.h"
 
@@ -534,6 +537,47 @@ int JSON_Fix(const char *filename)
     delete[] newbuf;
     return 0;
 }
+
+
+
+/// "anims": { "#import" : "generics.json" }
+/// "anims": { "#import" : { "file": "generics.json", "key": "animations", "replace": { "arg4" : "codefragment" }
+/// "anims": { "#import" : { "file": "generics.json", "key": "animations", "replace": { "arg4" : { "#import": } }
+/// "$moreanims": { "#import" : "generics.json" },
+/// "anims": [ "anim1", "anim2", "anim3", "$moreanims"] 
+void JSON_ResolveImport(JSON *j)
+{
+
+}
+
+/// j => "anims"
+void JSON_ScanImport(JSON *j)
+{
+    loopi(j->numchilds())
+    {
+        JSON *c = j->getitem(i);
+        JSON *g = c->child;
+        while(g)
+        {
+            JSON_ScanImport(g);
+            g = g->next;
+        }
+        if(!strcmp(c->name, "#import")) JSON_ResolveImport(c);
+    }
+}
+
+
+/// Resolve any #import filestructure advisers
+void JSON_ResolveImports(JSON *j)
+{
+    JSON *cur = j;
+    while(cur)
+    {
+
+    }
+
+}
+
 
 /// Create basic types:
 JSON *JSON_CreateBool(bool b)               { JSON *item= new JSON(); item->type = b ? JSON_TRUE : JSON_FALSE;  return item; }

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -1,7 +1,5 @@
 ///  JSON is used to store data-information
 ///  Rewrite of cJSON 1.0r58 in Inexor-optimized object-orientated C-ish C++
-///  Author: Malte "a_teammate" Haase
-///  Created:   31.12.2014
 ///  cJSON (Copyright (c) 2009 by Dave Gamble) is licensed under the MIT-license
 
 #include "engine.h"
@@ -689,3 +687,4 @@ void JSON::replaceitem(int which, JSON *newitem)
 // TODO:
 // render -> import commands automatisch wenn currentfile inkorrekt
 // refractor replace, additem, replaceimport
+// namespace

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -220,7 +220,7 @@ static const char *parse_value(JSON *item, const char *value)
     ep = value; return 0;    // failure.
 }
 
- // Render a value to text.
+/// Render a value to text.
 static char *print_value(JSON *item, int depth, bool fmt)
 {
     char *out = 0;
@@ -669,6 +669,7 @@ JSON *loadjson(const char *filename)
         return NULL;
     }
     j->currentfile = newstring(s);
+    foralljsonchildren(j, k, k->currentfile = j->currentfile;);
 
     delete[] buf;
     return j;

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -558,15 +558,15 @@ int JSON_Fix(const char *filename)
 /// "anims": [ "anim1", "anim2", "anim3", "$moreanims"]
 bool JSON_ReplaceImport(JSON *g)
 {
-    JSON *j = g->getitem(IMPORTPHRASE);
+    JSON *j = g->getchild(IMPORTPHRASE);
     JSON *f = NULL;       // the exporting file: "generics.json"
     JSON *newg = NULL;    // the JSON which will replace the old section
     string sourcedesc;    // importedsource description for the JSON struct, where it contents actually came from
 
     if(!j) return false;
-    JSON *src = j->getitem("file"); 
-    JSON *key = j->getitem("key");
-  //  JSON *replace = j->getitem("replace");
+    JSON *src = j->getchild("file"); 
+    JSON *key = j->getchild("key");
+  //  JSON *replace = j->getchild("replace");
     
     if(!src) { return false; }
     const char *srcname = src->valuestring;
@@ -576,7 +576,7 @@ bool JSON_ReplaceImport(JSON *g)
     if(!f) { return false; }
 
     if(key) {
-        newg = f->getitem(key->valuestring);
+        newg = f->getchild(key->valuestring);
         strcat_s(sourcedesc, "<>");
         strcat_s(sourcedesc, key->valuestring);
     }
@@ -605,7 +605,7 @@ void JSON_ResolveImports(JSON *j)
 {
     foralljson(j, 
     {
-        if(k->getitem(IMPORTPHRASE)) JSON_ReplaceImport(k);
+        if(k->getchild(IMPORTPHRASE)) JSON_ReplaceImport(k);
     }
     )
 }
@@ -661,7 +661,7 @@ char *JSON::render(bool formatted, bool minified) {
     return print_value(this, 0, formatted);
 }
 
-void JSON::additem(JSON *item)
+void JSON::addchild(JSON *item)
 {
     if(!item) return;
     
@@ -683,7 +683,7 @@ void JSON::additem(JSON *item)
     }
 }
 
-void JSON::replaceitem(int which, JSON *newitem)
+void JSON::replacechild(int which, JSON *newitem)
 {
     JSON *c = firstchild;
     while(c && which>0) { c = c->next; which--; }
@@ -707,5 +707,5 @@ void JSON::replaceitem(int which, JSON *newitem)
 
 // TODO:
 // render -> import commands automatisch wenn currentfile inkorrekt :) [DONE ? ]
-// refractor replace, additem, replaceimport
+// refractor replace, addchild, replaceimport
 // namespace

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -539,8 +539,7 @@ int JSON_Fix(const char *filename)
         conoutf("%s was malformatted but has been fixed automatically. \nThe original file has been overwritten, but backuped", found);
         //cutextension .. getextension
         defformatstring(backupname)("%s_backup", found);
-        rename(found, backupname);
-        j->save(found);
+        if(!rename(found, backupname)) j->save(found);
         delete j;
         delete[] buf;
         delete[] newbuf;

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -251,7 +251,7 @@ static const char *parse_array(JSON *item, const char *value)
     value = skip(value+1);
     if(*value==']') return value+1;    // empty array.
 
-    item->child = child = new JSON();
+    item->firstchild = child = new JSON();
     child->parent = item;
 
     value = skip( parse_value(child, skip(value)));    // skip any spacing, get the value.
@@ -278,7 +278,7 @@ static char *print_array(JSON *item, int depth, bool fmt)
     char *out = 0, *ptr, *ret;
     int len = 5;
 
-    JSON *child = item->child;
+    JSON *child = item->firstchild;
     int numentries = 0 , i = 0, fail = 0;
 
     // How many entries in the array?
@@ -296,7 +296,7 @@ static char *print_array(JSON *item, int depth, bool fmt)
     memset(entries, 0, numentries*sizeof(char*));
 
     // Retrieve all the results:
-    child = item->child;
+    child = item->firstchild;
     while (child && !fail)
     {
         ret = print_value(child, depth+1, fmt);
@@ -346,7 +346,7 @@ static const char *parse_object(JSON *item, const char *value)
     value = skip(value+1);
     if(*value=='}') return value+1;    // empty array.
 
-    item->child = child = new JSON();
+    item->firstchild = child = new JSON();
     child->parent = item;
 
     value = skip(parse_string(child, skip(value)));
@@ -386,7 +386,7 @@ static char *print_object(JSON *item, int depth, bool fmt)
     char *out = 0, *ptr, *ret, *str;
     int len=7, i=0;
 
-    JSON *child=item->child;
+    JSON *child = item->firstchild;
     int numentries=0, fail=0;
     // Count the number of entries.
     while (child) numentries++, child = child->next;
@@ -410,7 +410,7 @@ static char *print_object(JSON *item, int depth, bool fmt)
     memset(names, 0, sizeof(char*)*numentries);
 
     // Collect all the results into our arrays:
-    child = item->child;
+    child = item->firstchild;
     depth++;
     if(fmt) len+=depth;
     while (child)
@@ -593,7 +593,7 @@ bool JSON_ReplaceImport(JSON *g)
 
     // tell the others
     if(g->next) g->next->prev = newg;
-    if(g->parent->child == g) g->parent->child = newg;
+    if(g->parent->firstchild == g) g->parent->firstchild = newg;
     else g->prev->next = newg;
 
     newg->original = g;
@@ -673,8 +673,8 @@ void JSON::additem(JSON *item)
 
     item->parent = this;
 
-    JSON *c = child; //rewire:
-    if(!c) { child = item; }
+    JSON *c = firstchild; //rewire:
+    if(!c) { firstchild = item; }
     else
     { //last place in the chain
         while(c && c->next) c = c->next;
@@ -685,7 +685,7 @@ void JSON::additem(JSON *item)
 
 void JSON::replaceitem(int which, JSON *newitem)
 {
-    JSON *c = child;
+    JSON *c = firstchild;
     while(c && which>0) { c = c->next; which--; }
     if(!c) return;
 
@@ -700,7 +700,7 @@ void JSON::replaceitem(int which, JSON *newitem)
     newitem->prev = c->prev;
     if(newitem->next) newitem->next->prev = newitem;
 
-    if(c == child) child = newitem;
+    if(c == firstchild) firstchild = newitem;
     else newitem->prev->next = newitem;
     DELETEP(c);
 }

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -633,7 +633,7 @@ JSON *loadjson(const char *filename)
         //if(JSON_Fix(filename)) j = loadjson(filename);
         return NULL;
     }
-    j->currentdir = newstring(parentdir(s));
+    j->currentfile = newstring(s);
 
     delete[] buf;
     return j;
@@ -647,10 +647,10 @@ void JSON::additem(JSON *item)
 {
     if(!item) return;
     
-    if(strcmp(item->currentdir, currentdir))
+    if(strcmp(item->currentfile, currentfile))
     {
-        delete[] item->currentdir;
-        foralljson(this, k->currentdir = currentdir;);
+        delete[] item->currentfile;
+        foralljson(this, k->currentfile = currentfile;);
     }
     item->parent = this;
 
@@ -671,9 +671,9 @@ void JSON::replaceitem(int which, JSON *newitem)
     if(!c) return;
 
     if(type != JSON_ARRAY && !newitem->name) newitem->name = newstring(c->name); //misuse prevention
-    if(strcmp(newitem->currentdir, c->currentdir))
+    if(strcmp(newitem->currentfile, c->currentfile))
     {
-        foralljson(newitem, k->currentdir = c->currentdir;);
+        foralljson(newitem, k->currentfile = c->currentfile;);
     }
 
     newitem->parent = this;
@@ -687,6 +687,5 @@ void JSON::replaceitem(int which, JSON *newitem)
 }
 
 // TODO:
-// render -> import commands automatisch wenn currentdir inkorrekt
-// currentdir -> curfile (+ curdir)
+// render -> import commands automatisch wenn currentfile inkorrekt
 // refractor replace, additem, replaceimport

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -352,7 +352,7 @@ static const char *parse_object(JSON *item, const char *value)
     value = skip(parse_string(child, skip(value)));
     if(!value) return 0;
     child->name = child->valuestring;
-    child->valuestring = newstring("");
+    child->valuestring = NULL;
 
     if(*value!=':') { ep = value; return 0; }    // fail!
     value = skip(parse_value(child, skip(value+1)));    // skip any spacing, get the value.
@@ -368,7 +368,7 @@ static const char *parse_object(JSON *item, const char *value)
         value = skip(parse_string(child, skip(value+1)));
         if(!value) return 0;
         child->name = child->valuestring;
-        child->valuestring = newstring("");
+        child->valuestring = NULL;
 
         if(*value!=':') { ep = value; return 0; }    // fail!
         value = skip(parse_value( child, skip(value+1)));    // skip any spacing, get the value.
@@ -625,7 +625,7 @@ JSON *JSON_CreateInt(int num)               { JSON *item= new JSON(); item->type
 JSON *JSON_CreateFloat(float num)           { JSON *item= new JSON(); item->type = JSON_NUMBER;     item->valuefloat = num;     return item; }
 
 /// Create a JSON, set its type to String and allocate a valuestring for it.
-JSON *JSON_CreateString(const char *str)    { JSON *item= new JSON(); item->type = JSON_STRING;     item->valuestring = newstring(str);  return item; }
+JSON *JSON_CreateString(const char *str)    { if(!str) return NULL; JSON *item = new JSON(); item->type = JSON_STRING;     item->valuestring = newstring(str);  return item; }
 JSON *JSON_CreateArray()                    { JSON *item= new JSON(); item->type = JSON_ARRAY;      return item; }
 JSON *JSON_CreateObject()                   { JSON *item= new JSON(); item->type = JSON_OBJECT;     return item; }
 
@@ -689,7 +689,7 @@ void JSON::replaceitem(int which, JSON *newitem)
     while(c && which>0) { c = c->next; which--; }
     if(!c) return;
 
-    if(type != JSON_ARRAY && !newitem->name) newitem->name = newstring(c->name); //misuse prevention
+    if(type != JSON_ARRAY && !newitem->name && c->name) newitem->name = newstring(c->name); //misuse prevention
     if(strcmp(newitem->currentfile, c->currentfile))
     {
         foralljson(newitem, k->currentfile = c->currentfile;);

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -4,6 +4,15 @@
 
 #include "engine.h"
 
+// Debugging
+
+VARP(debugjson, 0, 0, 1);
+static const char *ep; //error pointer
+const char *JSON_GetError()
+{ 
+    return ep;
+}
+
  // Parse the input text to generate a number, and populate the result into item.
 static const char *parse_number(JSON *item, const char *num)
 {
@@ -52,7 +61,6 @@ static unsigned parse_hex4(const char *str)
 }
 
  // Parse the input text into an unescaped cstring, and populate item.
-static const char *ep; //error pointer
 static const unsigned char firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
 static const char *parse_string(JSON *item, const char *str)
 {
@@ -628,6 +636,8 @@ JSON *loadjson(const char *filename)
     JSON *j = JSON_Parse(buf);
     if(!j)
     {
+        conoutf(CON_WARN, "JSON File %s malformatted. (Use /debugjson to enable find error position)", s);
+        if(debugjson) conoutf(CON_DEBUG, "could not parse: %s", ep ? ep : "");
         //if(JSON_Fix(filename)) j = loadjson(filename);
         return NULL;
     }

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -655,7 +655,7 @@ JSON *loadjson(const char *filename)
 
     string s;
     copystring(s, filename);
-    char *buf = loadfile(findfile(path(s), ""), NULL);
+    char *buf = loadfile(path(s), NULL);
     if(!buf)
     {
         conoutf(CON_WARN, "could not find %s", s);

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -637,12 +637,10 @@ void testjson(const char *name)
 }
 COMMAND(testjson, "s");
 
-/// Create basic types:
+// Create basic types:
 JSON *JSON_CreateBool(bool b)               { JSON *item= new JSON(); item->type = b ? JSON_TRUE : JSON_FALSE;  return item; }
 JSON *JSON_CreateInt(int num)               { JSON *item= new JSON(); item->type = JSON_NUMBER;     item->valueint = num; item->valuefloat = num; return item; }
 JSON *JSON_CreateFloat(float num)           { JSON *item= new JSON(); item->type = JSON_NUMBER;     item->valuefloat = num;     return item; }
-
-/// Create a JSON containing just a valuestring.
 JSON *JSON_CreateString(const char *str)    { if(!str) return NULL; JSON *item = new JSON(); item->type = JSON_STRING;     item->valuestring = newstring(str);  return item; }
 JSON *JSON_CreateArray()                    { JSON *item= new JSON(); item->type = JSON_ARRAY;      return item; }
 JSON *JSON_CreateObject()                   { JSON *item= new JSON(); item->type = JSON_OBJECT;     return item; }
@@ -727,7 +725,6 @@ void JSON::replacechild(int which, JSON *newitem)
 }
 
 // TODO:
-// render -> import commands automatisch wenn currentfile inkorrekt [DONE ? ]
 // refractor replace, addchild, replaceimport
-// namespace
-// class instead of struct (?)
+// namespace ? 
+// class instead of struct ?

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -13,7 +13,7 @@ const char *JSON_GetError()
     return ep;
 }
 
- // Parse the input text to generate a number, and populate the result into item.
+/// Internal: Parse the input text to generate a number, and populate the result into item.
 static const char *parse_number(JSON *item, const char *num)
 {
     float n = 0, sign=1, scale=0; int subscale=0, signsubscale=1;
@@ -40,7 +40,7 @@ static const char *parse_number(JSON *item, const char *num)
     return num;
 }
 
- // Render the number nicely from the given item into a string.
+/// Internal: Render the number nicely from the given item into a string.
 static char *print_number(JSON *item)
 {
 	defformatstring(val) ("%g", item->valuefloat);
@@ -60,7 +60,7 @@ static unsigned parse_hex4(const char *str)
     return h;
 }
 
- // Parse the input text into an unescaped cstring, and populate item.
+/// Internal: Parse the input text into an unescaped cstring, and populate item.
 static const unsigned char firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
 static const char *parse_string(JSON *item, const char *str)
 {
@@ -127,7 +127,7 @@ static const char *parse_string(JSON *item, const char *str)
     return ptr;
 }
 
- // Render the cstring provided to an escaped version that can be printed.
+/// Internal: Render the cstring provided to an escaped version that can be printed.
 static char *print_string_ptr(const char *str)
 {
     const char *ptr; char *ptr2,*out; int len=0; unsigned char token;
@@ -169,10 +169,10 @@ static char *print_string_ptr(const char *str)
     return out;
 }
 
- // Invote print_string_ptr (which is useful) on an item.
+/// Internal: Invote print_string_ptr (which is useful) on an item.
 static char *print_string(JSON *item) { return print_string_ptr(item->valuestring); }
 
- // Predeclare these prototypes.
+/// Internal: Predeclare these prototypes.
 static const char *parse_value(JSON *item, const char *value);
 static char *print_value(JSON *item, int depth, bool fmt);
 static const char *parse_array(JSON *item, const char *value);
@@ -180,10 +180,10 @@ static char *print_array(JSON *item, int depth, bool fmt);
 static const char *parse_object(JSON *item, const char *value);
 static char *print_object(JSON *item, int depth, bool fmt);
 
- // Utility to jump whitespace and cr/lf
+/// Internal: Utility to jump whitespace and cr/lf
 static const char *skip(const char *in) {while (in && *in && (unsigned char)*in<=32) in++; return in;}
 
- // Parse an object - create a new root, and populate.
+/// Internal: Parse an object - create a new root, and populate.
 JSON *JSON_ParseWithOpts(const char *value, const char **return_parse_end, bool require_null_terminated)
 {
     const char *end = 0;
@@ -202,10 +202,10 @@ JSON *JSON_ParseWithOpts(const char *value, const char **return_parse_end, bool 
     if(return_parse_end) *return_parse_end = end;
     return c;
 }
- // Default options for JSON_Parse
+/// Internal: Default options for JSON_Parse
 JSON *JSON_Parse(const char *value) { return JSON_ParseWithOpts(value, 0, false); }
 
- // Parser core - when encountering text, process appropriately.
+/// Internal: Parser core - when encountering text, process appropriately.
 static const char *parse_value(JSON *item, const char *value)
 {
     if(!value)                        return 0;    // Fail on null.
@@ -220,7 +220,7 @@ static const char *parse_value(JSON *item, const char *value)
     ep = value; return 0;    // failure.
 }
 
-/// Render a value to text.
+/// Internal: Render a value to text.
 static char *print_value(JSON *item, int depth, bool fmt)
 {
     char *out = 0;
@@ -241,7 +241,7 @@ static char *print_value(JSON *item, int depth, bool fmt)
     return out;
 }
 
- // Build an array from input text.
+/// Internal: Build an array from input text.
 static const char *parse_array(JSON *item, const char *value)
 {
     JSON *child;
@@ -271,7 +271,7 @@ static const char *parse_array(JSON *item, const char *value)
     ep = value; return 0;    // malformed.
 }
 
- // Render an array to text
+/// Internal: Render an array to text
 static char *print_array(JSON *item, int depth, bool fmt)
 {
     char **entries;
@@ -336,7 +336,7 @@ static char *print_array(JSON *item, int depth, bool fmt)
     return out;
 }
 
- // Build an object from the text.
+/// Internal: Build an object from the text.
 static const char *parse_object(JSON *item, const char *value)
 {
     JSON *child;
@@ -379,7 +379,7 @@ static const char *parse_object(JSON *item, const char *value)
     ep = value; return 0;    // malformed.
 }
 
- // Render an object to text.
+/// Internal: Render an object to text.
 static char *print_object(JSON *item, int depth, bool fmt)
 {
     char **entries = 0, **names = 0;
@@ -458,7 +458,7 @@ static char *print_object(JSON *item, int depth, bool fmt)
     return out;
 }
 
-/// Minify JSON buffer (remove whitespaces and even comments)
+/// Minify JSON buffer (remove whitespaces and even comments).
 void JSON_Minify(char *json)
 {
     char *into = json;
@@ -617,7 +617,7 @@ bool JSON_ResolveImport(JSON *g)
     return true;
 }
 
-/// j => "anims"
+/// Load all occurences of import-markers from the referring json-files.
 void JSON_ResolveImports(JSON *j)
 {
     foralljson(j, k,
@@ -627,6 +627,7 @@ void JSON_ResolveImports(JSON *j)
     )
 }
 
+/// Load a JSON File and display its contents.
 void testjson(const char *name)
 {
     JSON *j = loadjson(name);

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -587,7 +587,8 @@ JSON *JSON_CreateString(const char *str)    { JSON *item= new JSON(); item->type
 JSON *JSON_CreateArray()                    { JSON *item= new JSON(); item->type = JSON_ARRAY;      return item; }
 JSON *JSON_CreateObject()                   { JSON *item= new JSON(); item->type = JSON_OBJECT;     return item; }
 
- /// Load a .json file
+/// Load a .json file.
+/// @sideeffects allocates memory for a JSON structure, needs to be deleted
 JSON *loadjson(const char *filename)
 {
     string s;

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -9,7 +9,7 @@
 VARP(debugjson, 0, 0, 1);
 static const char *ep; //error pointer
 const char *JSON_GetError()
-{ 
+{
     return ep;
 }
 
@@ -485,7 +485,7 @@ void JSON_Minify(char *json)
 }
 
 /// Basic and really simplistic routine to fix malformatted .json files
-/// It will replace the old version of your file on success and create a backup of the old one (called <filename>_backup.json) 
+/// It will replace the old version of your file on success and create a backup of the old one (called <filename>_backup.json)
 /// Currently it fixes: double commata, missing " for non-numeric strings
 int JSON_Fix(const char *filename)
 {
@@ -495,9 +495,9 @@ int JSON_Fix(const char *filename)
     char *buf = loadfile(found, NULL);
     if(!buf) return -1;
     JSON_Minify(buf);
-    
+
     size_t len = strlen(buf);
-    
+
     char *newbuf = new char[len + 1];
 
     size_t pos = 0; //current position in the newbuf
@@ -534,9 +534,9 @@ int JSON_Fix(const char *filename)
     }
 
     JSON *j = JSON_Parse(newbuf);
-    if(j) 
+    if(j)
     {
-        conoutf("%s was malformatted but has been fixed automatically. \nThe original file has been overwritten, but backuped");
+        conoutf("%s was malformatted but has been fixed automatically. \nThe original file has been overwritten, but backuped", found);
         //cutextension .. getextension
         defformatstring(backupname)("%s_backup", found);
         rename(found, backupname);
@@ -555,7 +555,7 @@ int JSON_Fix(const char *filename)
 #define IMPORTPHRASE "#import"
 
 /// Replace an occurence of string from in string src with string to.
-/// @example replace("hallo welt", 
+/// @example replace("hallo welt",
 // TODO
 
 
@@ -583,7 +583,7 @@ bool JSON_ResolveImport(JSON *g)
 
     if(!j) return false;
 
-    JSON *src = j->getchild("file"); 
+    JSON *src = j->getchild("file");
     JSON *key = j->getchild("key");
     JSON *replace = j->getchild("replace");
 
@@ -684,7 +684,7 @@ char *JSON::render(bool formatted, bool minified) {
 void JSON::addchild(JSON *item)
 {
     if(!item) return;
-    
+
     if(strcmp(item->currentfile, currentfile))
     {
         delete[] item->currentfile;

--- a/src/shared/json.cpp
+++ b/src/shared/json.cpp
@@ -566,7 +566,7 @@ void JSON_ResolveReplacements(JSON *g, JSON *replacements)
     {
         foralljson(g, h,
         {
-            if(strstr(g->name, k->name));
+            if(g->name && k->name && strstr(g->name, k->name));
         })
     })
 }
@@ -603,7 +603,7 @@ bool JSON_ResolveImport(JSON *g)
     JSON_ResolveReplacements(newg, replace);
 
     // Replace g with newg:
-    copystring(newg->name, g->name); // "anims"
+    if(g->name) copystring(newg->name, g->name); // "anims"
     newg->parent = g->parent;
 
     newg->next = g->next;
@@ -685,7 +685,7 @@ void JSON::addchild(JSON *item)
 {
     if(!item) return;
 
-    if(strcmp(item->currentfile, currentfile))
+    if(!currentfile || !item->currentfile || strcmp(item->currentfile, currentfile) )
     {
         delete[] item->currentfile;
         foralljson(item, k, k->currentfile = currentfile;);
@@ -710,7 +710,7 @@ void JSON::replacechild(int which, JSON *newitem)
     if(!c) return;
 
     if(type != JSON_ARRAY && !newitem->name && c->name) newitem->name = newstring(c->name); //misuse prevention
-    if(strcmp(newitem->currentfile, c->currentfile))
+    if(!currentfile || !newitem->currentfile || strcmp(newitem->currentfile, c->currentfile))
     {
         foralljson(newitem, k, k->currentfile = c->currentfile;);
     }

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -132,49 +132,61 @@ struct JSON
         return c;
     }
 
-    /// Get float of Object. 
-    /// Used if floatvalue is expected. otherwise returns -1
+    /// Get floatvalue of a specific child in an Object.
+    /// @return floatvalue of child or -1.0 if not found.
     float getchildfloat(const char *key)
     {
         JSON *sub = getchild(key);
         return sub ? sub->valuefloat : -1.0f;
     }
-
-    float getchildfloat(int item)        //Get float of Array. Used if floatvalue is expected. otherwise returns -1.0f
+    
+    /// Get floatvalue of a specific child in an Array.
+    /// @return floatvalue of child or -1.0 if not found.
+    float getchildfloat(int item)
     {
         JSON *sub = getchild(item);
         return sub ? sub->valuefloat : -1.0f;
     }
 
-    int getchildint(const char *key)     //Get int of Object. Used if value is expected to be int. otherwise returns -1
+    /// Get intvalue of a specific child in an Object.
+    /// @return intvalue of child or -1 if not found.
+    int getchildint(const char *key)
     {
         JSON *sub = getchild(key);
         return sub ? sub->valueint : -1;
     }
 
-    int getchildint(int item)            //Get child int of Array. Used if value is expected to be int. otherwise returns -1
+    /// Get intvalue of a specific child in an Array.
+    /// @return intvalue of child or -1 if not found.
+    int getchildint(int item)
     {
         JSON *sub = getchild(item);
         return sub ? sub->valueint : -1;
     }
 
-    const char *getchildstring(const char *key)     //Get string of Object. Used if value is expected to be a string. otherwise returns ""
+    /// Get (allways allocated!) string of a specific child in an Object.
+    /// @return intvalue of child or a new allocated string "" if not found.
+    /// @sideeffects allocates memory if no such key is found, needs deletion.
+    const char *getchildstring(const char *key)
     {
         JSON *sub = getchild(key);
         return sub ? sub->valuestring : newstring("");
     }
 
-    const char *getchildstring(int item)            //Get string of Array. Used if value is expected to be string. otherwise returns ""
+    /// Get (allways allocated!) string of a specific child in an Object.
+    /// @return intvalue of child or a new allocated string "" if not found.
+    /// @sideeffects allocates memory if no such key is found, needs deletion.
+    const char *getchildstring(int item)
     {
         JSON *sub = getchild(item);
         return sub ? sub->valuestring : newstring("");
     }
 
-    /// add Item to the last place of an Array (item == another JSON).
+    /// add a child to this JSON Array (at the last place, not setting a new name).
     void addchild(JSON *item);
 
-    /// add Item to Object (item == another JSON).
-    /// @param name is the new name of the item.
+    /// add a child to this JSON Object (at the last place).
+    /// @param name is the new key/name the added item will be accessed.
     void addchild(const char *name, JSON *item)
     { 
         if (!item) return;
@@ -185,8 +197,9 @@ struct JSON
         addchild(item);
     }
 
-    /// Remove Item from Array but do not delete it.
-    /// @param which tells which place to remove in the Array.
+    /// Remove Child from Array but do not delete it.
+    /// @param which specifies which place the Child is.
+    /// @return the detached Child.
     JSON *detachchild(int which)
     {
         JSON *c = firstchild;
@@ -199,8 +212,9 @@ struct JSON
         return c;
     }
 
-    /// Detach Item from Object but do not delete it.
-    /// @param name gives the name of the item.
+    /// Detach Child from Object but do not delete it.
+    /// @param name specifies the key/name of the Child.
+    /// @return the detached Child.
     JSON *detachchild(const char *name)
     {
         if(!name) return NULL;
@@ -211,16 +225,20 @@ struct JSON
         return NULL;
     }
 
-    void deletechild(int which) { JSON *c = detachchild(which); DELETEP(c); }        //Delete Item from Array
-    void deletechild(const char *name) { JSON *c = detachchild(name); DELETEP(c); }  //Delete Item from Object
+    /// Delete Child according to its position (from Array).
+    void deletechild(int which) { JSON *c = detachchild(which); DELETEP(c); }
+
+    /// Delete Child according to its name (from Object).
+    void deletechild(const char *name) { JSON *c = detachchild(name); DELETEP(c); }
     
-    /// Replace Item in Array with newitem.
+    /// Replace Child in an Array with newitem.
     /// @sideeffects Deletes the old item.
-    /// @param which represents which position in the Array the old item had.
-    /// of recognizing imported/replaced stuff.
+    /// @param which represents which position in the Array the old item has.
     void replacechild(int which, JSON *newitem);
 
-    /// Replace Item in Object.
+    /// Replace Child in an Object with newitem.
+    /// @sideeffects Deletes the old item.
+    /// @param name represents the key/name of the old item.
     void replacechild(const char *name, JSON *newitem)
     {
         if(!name) return;

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -87,7 +87,7 @@ struct JSON
     /// @return true after saving successfully.
     bool save(const char *filename, bool formatted = true)
     {
-        string s; 
+        string s;
         copystring(s, filename);
         stream *f = openutf8file(path(s), "w");
         if(!f) return false;
@@ -102,7 +102,7 @@ struct JSON
     /// Get number of children.
     /// More useful for arrays probably.
     int numchilds()
-    { 
+    {
         JSON *c = firstchild;
         int i = 0;
         while(c) { i++; c = c->next; }
@@ -139,7 +139,7 @@ struct JSON
         JSON *sub = getchild(key);
         return sub ? sub->valuefloat : -1.0f;
     }
-    
+
     /// Get floatvalue of a specific child in an Array.
     /// @return floatvalue of child or -1.0 if not found.
     float getchildfloat(int item)
@@ -188,7 +188,7 @@ struct JSON
     /// add a child to this JSON Object (at the last place).
     /// @param name is the new key/name the added item will be accessed.
     void addchild(const char *name, JSON *item)
-    { 
+    {
         if (!item) return;
         if(name) {
             delete[] item->name;
@@ -230,7 +230,7 @@ struct JSON
 
     /// Delete Child according to its name (from Object).
     void deletechild(const char *name) { JSON *c = detachchild(name); DELETEP(c); }
-    
+
     /// Replace Child in an Array with newitem.
     /// @sideeffects Deletes the old item.
     /// @param which represents which position in the Array the old item has.

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -76,10 +76,10 @@ struct JSON
         }
     }
     
-     //Returns rendered JSON, as you would find it in a file
+    /// Returns rendered JSON, as you would find it in a file.
     char *render(bool formatted = true, bool minified = false);
 
-     //Save's to a specific JSON-File
+    /// Save's to a specific .json-file
     void save(const char *filename)
     {
         string s; 
@@ -92,7 +92,9 @@ struct JSON
         currentdir = newstring(s);
     }
 
-    int numchilds()					  //Get number of children (if array or object, though not useful for objects)
+    /// Get number of children.
+    /// More useful for arrays probably.
+    int numchilds()
     { 
         JSON *c = child;
         int i = 0;
@@ -100,7 +102,9 @@ struct JSON
         return i;
     }
 
-    JSON *getitem(int item)           //Get Item of Array
+    /// Return Children number <item>.
+    /// Used for Arrays.
+    JSON *getitem(int item)
     {
         JSON *c = child;
         while (c && item > 0) {
@@ -110,14 +114,19 @@ struct JSON
         return c;
     }
 
-    JSON *getitem(const char *name)   /// Get Item of Object
+    /// Return Children with name <name>.
+    /// Used for Objects.
+    /// Case insensitive.
+    JSON *getitem(const char *name)
     {
         JSON *c = child;
         while (c && strcasecmp(c->name, name)) c = c->next;
         return c;
     }
 
-    float getfloat(const char *key)  /// Get float of Object. Used if floatvalue is expected. otherwise returns -1.0f
+    /// Get float of Object. 
+    /// Used if floatvalue is expected. otherwise returns -1
+    float getfloat(const char *key)
     {
         JSON *sub = getitem(key);
         return sub ? sub->valuefloat : -1.0f;

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -37,19 +37,15 @@ struct JSON
 
     JSON *original;                 /// Contains the original info if it got overridden by an import.
 
-    JSON() : next(NULL), prev(NULL), child(NULL), parent(NULL), type(0), valueint(0), valuefloat(0), original(NULL)
-    { 
-        name = newstring("");
-        valuestring = newstring("");
-        currentfile = newstring("");
-    }
+    JSON() : next(NULL), prev(NULL), child(NULL), parent(NULL), type(0), valuestring(NULL), valueint(0), valuefloat(0), name(NULL), currentfile(NULL), original(NULL) { }
 
     /// Copies contents from old, without copying the dependencies to other JSONs.
     JSON(JSON *old)
     {
+        JSON();
         type = old->type;
         valueint = old->valueint; valuefloat = old->valuefloat;
-        if(old->valuestring && old->valuestring[0]) valuestring = newstring(old->valuestring);
+        if(old->valuestring) valuestring = newstring(old->valuestring);
         if(old->name) name = newstring(old->name);
         if(old->currentfile) currentfile = newstring(old->currentfile);
 
@@ -179,7 +175,7 @@ struct JSON
     { 
         if (!item) return;
 		delete[] item->name;
-        item->name = newstring(name);
+        if(name) item->name = newstring(name);
         additem(item);
     }
 
@@ -225,7 +221,7 @@ struct JSON
         while(c && strcasecmp(c->name, name)) { i++; c = c->next; }
         if(!c) return;
 
-        newitem->name = newstring(name);
+        if(name) newitem->name = newstring(name);
         replaceitem(i, newitem);
     }
 };

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -236,8 +236,9 @@ extern JSON *JSON_CreateArray();  //new ordered list. access: position
 extern JSON *JSON_CreateObject(); //new unordered list. access: name
 
 /// Executes b for all JSON elements below the given (t), but not t itself.
-/// Use "k" to access these JSON subelements.
-#define foralljsonchildren(t, b) \
+/// @param k is the variable name to access these JSON subelements.
+/// @example foralljsonchildren(rootjson, j, j->valuestring = NULL)
+#define foralljsonchildren(t, k, b) \
 { \
     JSON *curchildlayer = t->firstchild; \
     while(curchildlayer) \
@@ -246,15 +247,16 @@ extern JSON *JSON_CreateObject(); //new unordered list. access: name
         while(k) \
         { \
             b; \
-            k = k->next; \
+            k = (k)->next; \
         } \
         curchildlayer = curchildlayer->firstchild; \
     } \
 }
 
 /// Executes b for all JSON elements below the given (t) and for the given one.
-/// Use "k" to access all these JSON subelements.
-#define foralljson(t, b)     JSON *k = t; if(k) { b; } foralljsonchildren(t, b)
+/// @param k is the variable name to access all these JSON subelements.
+/// @example foralljson(rootjson, j, { j->name = newstring("allocated string") })
+#define foralljson(t, k, b)     JSON *k = t; if(k) { b; } foralljsonchildren(t, k, b)
 
 #endif // JSON_H
 

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -1,7 +1,7 @@
 ///  JSON is used to store data-information
 ///  Rewrite of cJSON 1.0r58 in Inexor-optimized object-orientated C-ish C++
 ///  Author: Malte "a_teammate" Haase
-///  Date:   31.12.2014
+///  Created:   31.12.2014
 ///  cJSON (Copyright (c) 2009 by Dave Gamble) is licensed under the MIT-license
 
 
@@ -36,7 +36,7 @@ struct JSON
 
     const char *currentdir;         /// The parent directory of the .json-file ( If the JSON is the result of a .json-file beeing loaded)
 
-    JSON() : next(NULL), prev(NULL), child(NULL), type(0), valueint(0), valuefloat(0), currentdir(NULL)  { name = newstring(""); valuestring = newstring(""); currentdir = newstring(""); }
+    JSON() : next(NULL), prev(NULL), child(NULL), type(0), valueint(0), valuefloat(0) { name = newstring(""); valuestring = newstring(""); currentdir = newstring(""); }
 
     JSON(JSON *old)       /// Copy constructor
     {
@@ -110,14 +110,14 @@ struct JSON
         return c;
     }
 
-    JSON *getitem(const char *name)   //Get Item of Object
+    JSON *getitem(const char *name)   /// Get Item of Object
     {
         JSON *c = child;
         while (c && strcasecmp(c->name, name)) c = c->next;
         return c;
     }
 
-    float getfloat(const char *key)  //Get float of Object. Used if floatvalue is expected. otherwise returns -1.0f
+    float getfloat(const char *key)  /// Get float of Object. Used if floatvalue is expected. otherwise returns -1.0f
     {
         JSON *sub = getitem(key);
         return sub ? sub->valuefloat : -1.0f;

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -35,9 +35,9 @@ struct JSON
 
     char *name;                     /// The item's name string, if the item in an object this is equivalent to the key. In an array its the string of the value!
 
-    const char *currentdir;         /// The parent directory of the .json-file ( If the JSON is the result of a .json-file beeing loaded)
+    const char *currentfile;         /// The parent directory of the .json-file ( If the JSON is the result of a .json-file beeing loaded)
 
-    JSON() : next(NULL), prev(NULL), child(NULL), parent(NULL), type(0), valueint(0), valuefloat(0) { name = newstring(""); valuestring = newstring(""); currentdir = newstring(""); }
+    JSON() : next(NULL), prev(NULL), child(NULL), parent(NULL), type(0), valueint(0), valuefloat(0) { name = newstring(""); valuestring = newstring(""); currentfile = newstring(""); }
 
     /// Copies contents from old, without copying the dependencies to other JSONs.
     JSON(JSON *old)
@@ -46,7 +46,7 @@ struct JSON
         valueint = old->valueint; valuefloat = old->valuefloat;
         if(old->valuestring && old->valuestring[0]) valuestring = newstring(old->valuestring);
         if(old->name) name = newstring(old->name);
-        if(old->currentdir) currentdir = newstring(old->currentdir);
+        if(old->currentfile) currentfile = newstring(old->currentfile);
 
         //copy children:
         JSON *loop = old->child, *last = NULL;
@@ -69,7 +69,7 @@ struct JSON
     {
         DELETEA(name);
         DELETEA(valuestring);
-        DELETEA(currentdir);
+        DELETEA(currentfile);
         JSON *c = child;
         while (c)
         {
@@ -92,7 +92,7 @@ struct JSON
         char *buf = render();
         f->putstring(buf);
         delete f;
-        currentdir = newstring(s);
+        currentfile = newstring(s);
     }
 
     /// Get number of children.

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -1,7 +1,5 @@
 ///  JSON is used to store data-information
 ///  Rewrite of cJSON 1.0r58 in Inexor-optimized object-orientated C-ish C++
-///  Author: Malte "a_teammate" Haase
-///  Created:   31.12.2014
 ///  cJSON (Copyright (c) 2009 by Dave Gamble) is licensed under the MIT-license
 
 

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -90,7 +90,7 @@ struct JSON
         string s; 
         copystring(s, filename);
         stream *f = openutf8file(path(s), "w");
-        if(!f) { conoutf(CON_WARN, "could not save %s", s); return false; }
+        if(!f) return false;
         char *buf = render();
         f->putstring(buf);
         delete f;

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -33,9 +33,16 @@ struct JSON
 
     char *name;                     /// The item's name string, if the item in an object this is equivalent to the key. In an array its the string of the value!
 
-    const char *currentfile;         /// The parent directory of the .json-file ( If the JSON is the result of a .json-file beeing loaded)
+    const char *currentfile;        /// The parent directory of the .json-file ( If the JSON is the result of a .json-file beeing loaded)
 
-    JSON() : next(NULL), prev(NULL), child(NULL), parent(NULL), type(0), valueint(0), valuefloat(0) { name = newstring(""); valuestring = newstring(""); currentfile = newstring(""); }
+    JSON *original;                 /// Contains the original info if it got overridden by an import.
+
+    JSON() : next(NULL), prev(NULL), child(NULL), parent(NULL), type(0), valueint(0), valuefloat(0), original(NULL)
+    { 
+        name = newstring("");
+        valuestring = newstring("");
+        currentfile = newstring("");
+    }
 
     /// Copies contents from old, without copying the dependencies to other JSONs.
     JSON(JSON *old)

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -85,13 +85,13 @@ struct JSON
 
     /// Save's to a specific .json-file.
     /// @return true after saving successfully.
-    bool save(const char *filename)
+    bool save(const char *filename, bool formatted = true)
     {
         string s; 
         copystring(s, filename);
         stream *f = openutf8file(path(s), "w");
         if(!f) return false;
-        char *buf = render();
+        char *buf = render(formatted);
         f->putstring(buf);
         delete f;
         delete[] currentfile;

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -1,5 +1,10 @@
-//  Rewrite of cJSON 1.0r58 in Inexor-optimized object-orientated C-ish C++
-//  cJSON (Copyright (c) 2009 by Dave Gamble) is licensed under the MIT-license
+///  JSON is used to store data-information
+///  Rewrite of cJSON 1.0r58 in Inexor-optimized object-orientated C-ish C++
+///  Author: Malte "a_teammate" Haase
+///  Date:   31.12.2014
+///  cJSON (Copyright (c) 2009 by Dave Gamble) is licensed under the MIT-license
+
+
 #ifndef __JSON__H
 #define __JSON__H
 
@@ -13,8 +18,9 @@ enum {
     JSON_STRING,
     JSON_ARRAY,                     //ordered list [ ]
     JSON_OBJECT                     //unordered list { }
-}; // JSON types
+}; /// JSON Types
 
+/// A Class to hold the parsed data of a json-file
 struct JSON
 {
     JSON *next, *prev;   // next/prev allow you to walk array/object chains.
@@ -26,16 +32,19 @@ struct JSON
     int valueint;                   // The item's number, if type==JSON_Number
     float valuefloat;               // The item's number, if type==JSON_Number
 
-    char *name;                     // The item's name string, if the item in an object this is equivalent to the key. In an array its the string of the value!
+    char *name;                     /// The item's name string, if the item in an object this is equivalent to the key. In an array its the string of the value!
 
-	JSON() : next(NULL), prev(NULL), child(NULL), type(0), valueint(0), valuefloat(0)  { name = newstring(""); valuestring = newstring(""); }
+    const char *currentdir;         /// The parent directory of the .json-file ( If the JSON is the result of a .json-file beeing loaded)
 
-    JSON(JSON *old)       //Copy constructor
+    JSON() : next(NULL), prev(NULL), child(NULL), type(0), valueint(0), valuefloat(0), currentdir(NULL)  { name = newstring(""); valuestring = newstring(""); currentdir = newstring(""); }
+
+    JSON(JSON *old)       /// Copy constructor
     {
         type = old->type;
         valueint = old->valueint; valuefloat = old->valuefloat;
         if(old->valuestring && old->valuestring[0]) valuestring = newstring(old->valuestring);
         if(old->name) name = newstring(old->name);
+        if(old->currentdir) currentdir = newstring(old->currentdir);
 
         //copy children:
         JSON *loop = old->child, *last = NULL;
@@ -57,6 +66,7 @@ struct JSON
     {
         DELETEA(name);
         DELETEA(valuestring);
+        DELETEA(currentdir);
         JSON *c = child;
         while (c)
         {
@@ -79,6 +89,7 @@ struct JSON
         char *buf = render();
         f->putstring(buf);
         delete f;
+        currentdir = newstring(s);
     }
 
     int numchilds()					  //Get number of children (if array or object, though not useful for objects)

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -255,14 +255,33 @@ struct JSON
     }
 };
 
+/// Load a .json file.
+/// Prints out the error position if it failed to parse if debugjson is enabled.
+/// @sideeffects allocates memory for a JSON structure, needs to be deleted.
 extern JSON *loadjson(const char *filename);
 
+
+/// Create a JSON with a boolean value.
 extern JSON *JSON_CreateBool(bool b);
+
+/// Create a JSON with given integer number as value.
 extern JSON *JSON_CreateInt(int num);
+
+/// Create a JSON with given floating point number as value.
 extern JSON *JSON_CreateFloat(float num);
+
+/// Create a JSON containing just a valuestring.
 extern JSON *JSON_CreateString(const char *str);
-extern JSON *JSON_CreateArray();  //new ordered list. access: position
-extern JSON *JSON_CreateObject(); //new unordered list. access: name
+
+/// Create a new ordered list.
+/// Access childs through its position number.
+extern JSON *JSON_CreateArray();
+
+/// Create a new unordered list.
+/// Access Childs through their keys (name-strings).
+extern JSON *JSON_CreateObject();
+
+
 
 /// Executes b for all JSON elements below the given (t), but not t itself.
 /// @param k is the variable name to access these JSON subelements.

--- a/src/shared/json.h
+++ b/src/shared/json.h
@@ -106,13 +106,13 @@ struct JSON
         return i;
     }
 
-    /// Return Children number <item>.
+    /// Return Children of a specific number.
     /// Used for Arrays.
-    JSON *getitem(int item)
+    JSON *getchild(int number)
     {
         JSON *c = firstchild;
-        while (c && item > 0) {
-            item--;
+        while (c && number > 0) {
+            number--;
             c = c->next;
         }
         return c;
@@ -121,7 +121,7 @@ struct JSON
     /// Return Children with name <name>.
     /// Used for Objects.
     /// Case insensitive.
-    JSON *getitem(const char *name)
+    JSON *getchild(const char *name)
     {
         JSON *c = firstchild;
         while (c && strcasecmp(c->name, name)) c = c->next;
@@ -130,58 +130,58 @@ struct JSON
 
     /// Get float of Object. 
     /// Used if floatvalue is expected. otherwise returns -1
-    float getfloat(const char *key)
+    float getchildfloat(const char *key)
     {
-        JSON *sub = getitem(key);
+        JSON *sub = getchild(key);
         return sub ? sub->valuefloat : -1.0f;
     }
 
-    float getfloat(int item)        //Get float of Array. Used if floatvalue is expected. otherwise returns -1.0f
+    float getchildfloat(int item)        //Get float of Array. Used if floatvalue is expected. otherwise returns -1.0f
     {
-        JSON *sub = getitem(item);
+        JSON *sub = getchild(item);
         return sub ? sub->valuefloat : -1.0f;
     }
 
-    int getint(const char *key)     //Get int of Object. Used if value is expected to be int. otherwise returns -1
+    int getchildint(const char *key)     //Get int of Object. Used if value is expected to be int. otherwise returns -1
     {
-        JSON *sub = getitem(key);
+        JSON *sub = getchild(key);
         return sub ? sub->valueint : -1;
     }
 
-    int getint(int item)            //Get int of Array. Used if value is expected to be int. otherwise returns -1
+    int getchildint(int item)            //Get child int of Array. Used if value is expected to be int. otherwise returns -1
     {
-        JSON *sub = getitem(item);
+        JSON *sub = getchild(item);
         return sub ? sub->valueint : -1;
     }
 
-    const char *getstring(const char *key)     //Get string of Object. Used if value is expected to be a string. otherwise returns ""
+    const char *getchildstring(const char *key)     //Get string of Object. Used if value is expected to be a string. otherwise returns ""
     {
-        JSON *sub = getitem(key);
+        JSON *sub = getchild(key);
         return sub ? sub->valuestring : newstring("");
     }
 
     const char *getstring(int item)            //Get string of Array. Used if value is expected to be string. otherwise returns ""
     {
-        JSON *sub = getitem(item);
+        JSON *sub = getchild(item);
         return sub ? sub->valuestring : newstring("");
     }
 
     /// add Item to the last place of an Array (item == another JSON).
-    void additem(JSON *item);
+    void addchild(JSON *item);
 
     /// add Item to Object (item == another JSON).
     /// @param name is the new name of the item.
-    void additem(const char *name, JSON *item)
+    void addchild(const char *name, JSON *item)
     { 
         if (!item) return;
 		delete[] item->name;
         if(name) item->name = newstring(name);
-        additem(item);
+        addchild(item);
     }
 
     /// Remove Item from Array but do not delete it.
     /// @param which tells which place to remove in the Array.
-    JSON *detachitem(int which)
+    JSON *detachchild(int which)
     {
         JSON *c = firstchild;
         while (c && which>0) { c = c->next; which--; }
@@ -195,26 +195,26 @@ struct JSON
 
     /// Detach Item from Object but do not delete it.
     /// @param name gives the name of the item.
-    JSON *detachitem(const char *name)
+    JSON *detachchild(const char *name)
     {
         int i=0;
         JSON *c = firstchild;
         while (c && strcasecmp(c->name, name)){ i++; c = c->next; }
-        if (c) return JSON::detachitem(i);
+        if (c) return JSON::detachchild(i);
         return NULL;
     }
 
-    void deleteitem(int which) { JSON *c = detachitem(which); DELETEP(c); }        //Delete Item from Array
-    void deleteitem(const char *name) { JSON *c = detachitem(name); DELETEP(c); }  //Delete Item from Object
+    void deletechild(int which) { JSON *c = detachchild(which); DELETEP(c); }        //Delete Item from Array
+    void deletechild(const char *name) { JSON *c = detachchild(name); DELETEP(c); }  //Delete Item from Object
     
     /// Replace Item in Array with newitem.
     /// @sideeffects Deletes the old item.
     /// @param which represents which position in the Array the old item had.
     /// of recognizing imported/replaced stuff.
-    void replaceitem(int which, JSON *newitem);
+    void replacechild(int which, JSON *newitem);
 
     /// Replace Item in Object.
-    void replaceitem(const char *name, JSON *newitem)
+    void replacechild(const char *name, JSON *newitem)
     {
         int i = 0;
         JSON *c = firstchild;
@@ -222,7 +222,7 @@ struct JSON
         if(!c) return;
 
         if(name) newitem->name = newstring(name);
-        replaceitem(i, newitem);
+        replacechild(i, newitem);
     }
 };
 


### PR DESCRIPTION
simplifies the JSON API a bit and make it more usable.

During the work on the new texture system i made a few changes to the api.

* `#import` command to easily import content from another json
  * description + wiki entry will follow since thats gonna be really powerful
  * additions are planned
* add foralljsonchildren macro to execute body for all JSONs below the given
* add foralljson macro to execute body for all JSON below + the given
* char pointers are not allocated by default but NULL 
   * makes checking against that easier
   * needs more secure checks though
* "getitem" becomes "getchild"
* "getfloat" becomes "getchildfloat"
   * if you want to access the value of a JSON float you would use it directly (JSON->valuefloat)
* Improved Doc.
* fixes