### PR TITLE
a_teammate/fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,9 @@ if(OS_LINUX OR (OS_WINDOWS AND NOT MSVC))
     # Allow the Large File Support (LFS) interface to replace the old interface.
     add_definitions(-D_FILE_OFFSET_BITS=64)
 
+    # Do not use STRICT_ANSI (important for some MINGW versions)
+    add_definitions(-U__STRICT_ANSI__)
+
     # Define where to move the binary by install
     set(EXE_SUB_DIR "bin/linux/${PROJECT_ARCH}")
 endif()

--- a/src/engine/3dgui.cpp
+++ b/src/engine/3dgui.cpp
@@ -11,6 +11,7 @@
 
 #include "engine.h"
 #include "textedit.h"
+#include "filesystem.h"
 
 static struct gui *windowhit = NULL;
 static bool layoutpass, actionon = false;
@@ -43,7 +44,6 @@ static float cursorx = 0.5f, cursory = 0.5f;
 VARP(guiautotab, 6, 16, 40);
 VARP(guiclicktab, 0, 0, 1);
 VARP(guifadein, 0, 1, 1);
-SVARP(icondir, "media/interface/icon");
 
 struct gui : g3d_gui
 {
@@ -361,7 +361,11 @@ struct gui : g3d_gui
                     glEnable(GL_TEXTURE_2D);
                     defaultshader->set();
                 }
-				if(!overlaytex) overlaytex = textureload(tempformatstring("%s/guioverlay.png", interfacedir), 3);
+                if(!overlaytex) {
+                    string otname;
+                    inexor::filesystem::appendmediadir(otname, "guioverlay.png", DIR_UI);
+                    overlaytex = textureload(otname, 3);
+                }
                 glColor3fv(light.v);
                 glBindTexture(GL_TEXTURE_2D, overlaytex->id);
                 rect_(xi, yi, xs, ys, 0);
@@ -426,7 +430,11 @@ struct gui : g3d_gui
                     glEnable(GL_TEXTURE_2D);
                     defaultshader->set();
                 }
-				if(!overlaytex) overlaytex = textureload(tempformatstring("%s/guioverlay.png", interfacedir), 3);
+                if(!overlaytex) {
+                    string otname;
+                    inexor::filesystem::appendmediadir(otname, "guioverlay.png", DIR_UI);
+                    overlaytex = textureload(otname, 3);
+                }
                 glColor3fv(light.v);
                 glBindTexture(GL_TEXTURE_2D, overlaytex->id);
                 rect_(xi, yi, xs, ys, 0);
@@ -643,7 +651,11 @@ struct gui : g3d_gui
 
         if(overlaid)
         {
-            if(!overlaytex) overlaytex = textureload(tempformatstring("%s/guioverlay.png", interfacedir), 3);
+            if(!overlaytex) {
+                string otname;
+                inexor::filesystem::appendmediadir(otname, "guioverlay.png", DIR_UI);
+                overlaytex = textureload(otname, 3);
+            }
             glBindTexture(GL_TEXTURE_2D, overlaytex->id);
             glColor3fv(light.v);
             rect_(x, y, xs, ys, 0);
@@ -729,7 +741,11 @@ struct gui : g3d_gui
         defaultshader->set();
         if(overlaid) 
         {
-            if(!overlaytex) overlaytex = textureload(tempformatstring("%s/guioverlay.png", interfacedir), 3);
+            if(!overlaytex) {
+                string otname;
+                inexor::filesystem::appendmediadir(otname, "guioverlay.png", DIR_UI);
+                overlaytex = textureload(otname, 3);
+            }
             glBindTexture(GL_TEXTURE_2D, overlaytex->id);
             glColor3fv(light.v);
             rect_(x, y, xs, ys, 0);
@@ -740,7 +756,11 @@ struct gui : g3d_gui
     {		
         if(visible())
         {
-            if(!slidertex) slidertex = textureload(tempformatstring("%s/guislider.png", interfacedir), 3);
+            if(!slidertex) {
+                string otname;
+                inexor::filesystem::appendmediadir(otname, "guislider.png", DIR_UI);
+                slidertex = textureload(otname, 3);
+            }
             glBindTexture(GL_TEXTURE_2D, slidertex->id);
             if(percent < 0.99f) 
             {
@@ -790,7 +810,9 @@ struct gui : g3d_gui
                 if(icon[0] != ' ')
                 {
                     const char *ext = strrchr(icon, '.');
-					icon_(textureload(tempformatstring("%s/%s%s", icondir, icon, ext ? "" : ".jpg"), 3), false, x, cury, ICON_SIZE, clickable && hit);
+                    static string iname;
+                    inexor::filesystem::appendmediadir(iname, icon, DIR_ICON, ext ? NULL : ".jpg");
+                    icon_(textureload(iname, 3), false, x, cury, ICON_SIZE, clickable && hit);
                 }
                 x += ICON_SIZE;
             }
@@ -806,7 +828,11 @@ struct gui : g3d_gui
 
     static void drawskin(int x, int y, int gapw, int gaph, int start, int n, int passes = 1, const vec &light = vec(1, 1, 1), float alpha = 0.80f)//int vleft, int vright, int vtop, int vbottom, int start, int n) 
     {
-		if(!skintex) skintex = textureload(tempformatstring("%s/guiskin.png", interfacedir), 3);
+        if(!skintex) {
+            static string stname;
+            inexor::filesystem::appendmediadir(stname, "guiskin.png", DIR_UI);
+            skintex = textureload(stname, 3);
+        }
         glBindTexture(GL_TEXTURE_2D, skintex->id);
         int gapx1 = INT_MAX, gapy1 = INT_MAX, gapx2 = INT_MAX, gapy2 = INT_MAX;
         float wscale = 1.0f/(SKIN_W*SKIN_SCALE), hscale = 1.0f/(SKIN_H*SKIN_SCALE);

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -613,8 +613,6 @@ extern void renderblob(int type, const vec &o, float radius, float fade = 1);
 extern void flushblobs();
 
 // rendersky
-extern char *skyboxdir;
-
 extern int explicitsky;
 extern double skyarea;
 

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -273,7 +273,7 @@ void renderbackground(const char *caption, Texture *mapshot, const char *mapname
     {
         glColor3f(1, 1, 1);
 		
-        settexture(tempformatstring("%s/background.png", interfacedir), 0);
+        settexture("media/interface/background.png", 0);
         float bu = w*0.67f/256.0f + backgroundu, bv = h*0.67f/256.0f + backgroundv;
         glBegin(GL_TRIANGLE_STRIP);
         glTexCoord2f(0,  0);  glVertex2f(0, 0);
@@ -284,7 +284,7 @@ void renderbackground(const char *caption, Texture *mapshot, const char *mapname
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         glEnable(GL_BLEND);
 
-		settexture(tempformatstring("%s/background_detail.png", interfacedir), 0);
+		settexture("media/interface/background_detail.png", 0);
         float du = w*0.8f/512.0f + detailu, dv = h*0.8f/512.0f + detailv;
         glBegin(GL_TRIANGLE_STRIP);
         glTexCoord2f(0,  0);  glVertex2f(0, 0);
@@ -293,7 +293,7 @@ void renderbackground(const char *caption, Texture *mapshot, const char *mapname
         glTexCoord2f(du, dv); glVertex2f(w, h);
         glEnd();
 
-        settexture(tempformatstring("%s/background_decal.png", interfacedir), 3);
+        settexture("media/interface/background_decal.png", 3);
         glBegin(GL_QUADS);
         loopj(numdecals)
         {
@@ -359,7 +359,7 @@ void renderbackground(const char *caption, Texture *mapshot, const char *mapname
                 glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             }        
 
-			settexture(tempformatstring("%s/mapshot_frame.png", interfacedir), 3);
+			settexture("media/interface/mapshot_frame.png", 3);
             glBegin(GL_TRIANGLE_STRIP);
             glTexCoord2f(0, 0); glVertex2f(x,    y);
             glTexCoord2f(1, 0); glVertex2f(x+sz, y);
@@ -444,7 +444,7 @@ void renderprogress(float bar, const char *text, GLuint tex, bool background)
           fu1 = 0/512.0f, fu2 = 511/512.0f,
           fv1 = 0/64.0f, fv2 = 52/64.0f;
 
-	settexture(tempformatstring("%s/loading_frame.png", interfacedir), 3);
+	settexture("media/interface/loading_frame.png", 3);
     glBegin(GL_TRIANGLE_STRIP);
     glTexCoord2f(fu1, fv1); glVertex2f(fx,    fy);
     glTexCoord2f(fu2, fv1); glVertex2f(fx+fw, fy);
@@ -464,7 +464,7 @@ void renderprogress(float bar, const char *text, GLuint tex, bool background)
           ex = bx+sw + max(mw*bar, fw*7/511.0f);
     if(bar > 0)
     {
-		settexture(tempformatstring("%s/loading_bar.png", interfacedir), 3);
+		settexture("media/interface/loading_bar.png", 3);
         glBegin(GL_QUADS);
         glTexCoord2f(su1, bv1); glVertex2f(bx,    by);
         glTexCoord2f(su2, bv1); glVertex2f(bx+sw, by);
@@ -510,7 +510,7 @@ void renderprogress(float bar, const char *text, GLuint tex, bool background)
 
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-		settexture(tempformatstring("%s/mapshot_frame.png", interfacedir), 3);
+		settexture("media/interface/mapshot_frame.png", 3);
         glBegin(GL_TRIANGLE_STRIP);
         glTexCoord2f(0, 0); glVertex2f(x,    y);
         glTexCoord2f(1, 0); glVertex2f(x+sz, y);

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -5,6 +5,7 @@
 
 #include "engine.h"
 #include "rpc/rpc_sb_compat.h"
+#include "filesystem.h"
 
 /// extern functions and data here
 extern void cleargamma();
@@ -194,8 +195,6 @@ void writeinitcfg()
 
 /// ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 /// main menu background and loading screen renderer
-
-SVARP(interfacedir, "media/interface");
 
 /// create a resolution suggestion by scaling down the larger side of the 2 screen dimensions.
 /// @warning this is a call by reference function!

--- a/src/engine/pch.cpp
+++ b/src/engine/pch.cpp
@@ -1,2 +1,0 @@
-#include "engine.h"
-

--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -2289,7 +2289,7 @@ ICOMMAND(getcrosshair, "i", (int *i),
     const char *name = "";
     if(*i >= 0 && *i < MAXCROSSHAIRS)
     {
-        name = crosshairs[*i] ? crosshairs[*i]->name : game::defaultcrosshair(*i);
+        name = crosshairs[*i] ? crosshairs[*i]->name : tempformatstring("%s/%s", crosshairdir, game::defaultcrosshair(*i));
     }
     result(name);
 });

--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -1,6 +1,7 @@
 // rendergl.cpp: core opengl rendering stuff
 
 #include "engine.h"
+#include "filesystem.h"
 
 bool hasVBO = false, hasDRE = false, hasOQ = false, hasTR = false, hasFBO = false, hasDS = false, hasTF = false, hasBE = false, hasBC = false, hasCM = false, hasNP2 = false, hasTC = false, hasS3TC = false, hasFXT1 = false, hasTE = false, hasMT = false, hasD3 = false, hasAF = false, hasVP2 = false, hasVP3 = false, hasPP = false, hasMDA = false, hasTE3 = false, hasTE4 = false, hasVP = false, hasFP = false, hasGLSL = false, hasGM = false, hasNVFB = false, hasSGIDT = false, hasSGISH = false, hasDT = false, hasSH = false, hasNVPCF = false, hasRN = false, hasPBO = false, hasFBB = false, hasUBO = false, hasBUE = false, hasMBR = false, hasFC = false, hasTEX = false;
 int hasstencil = 0;
@@ -2228,7 +2229,8 @@ void drawdamagescreen(int w, int h)
 
     static Texture *damagetex = NULL;
     if(!damagetex) {
-        defformatstring(damagetex_filename)("%s/damage.png", interfacedir);
+        string damagetex_filename;
+        inexor::filesystem::appendmediadir(damagetex_filename, "damage.png", DIR_UI);
     	damagetex = textureload(damagetex_filename, 3);
     }
 

--- a/src/engine/rendersky.cpp
+++ b/src/engine/rendersky.cpp
@@ -1,8 +1,8 @@
 #include "engine.h"
+#include "filesystem.h"
 
 Texture *sky[6] = { 0, 0, 0, 0, 0, 0 }, *clouds[6] = { 0, 0, 0, 0, 0, 0 };
 
-SVARP(skyboxdir, "media/skybox");
 void loadsky(const char *basename, Texture *texs[6])
 {
     const char *wildcard = strchr(basename, '*');
@@ -10,7 +10,8 @@ void loadsky(const char *basename, Texture *texs[6])
     {
         const char *side = cubemapsides[i].name;
         string name;
-        copystring(name, makerelpath(skyboxdir, basename));
+        inexor::filesystem::getmedianame(name, basename, DIR_SKYBOX);
+
         if(wildcard)
         {
             char *chop = strchr(name, '*');
@@ -37,7 +38,8 @@ Texture *loadskyoverlay(const char *basename)
 {
     const char *ext = strrchr(basename, '.'); 
     string name;
-    copystring(name, makerelpath(skyboxdir, basename));
+    inexor::filesystem::getmedianame(name, basename, DIR_SKYBOX);
+
     Texture *t = notexture;
     if(ext) t = textureload(name, 0, true, false);
     else

--- a/src/engine/texture.cpp
+++ b/src/engine/texture.cpp
@@ -1728,8 +1728,7 @@ void texture(char *type, char *name, int *rot, int *xoffset, int *yoffset, float
     st.type = tnum;
     st.combined = -1;
     st.t = NULL;
-	if(name && strpbrk(name, "/\\")) copystring(st.name, makerelpath(getcurexecdir(), name)); //relative path to current folder
-    else copystring(st.name, name);
+    inexor::filesystem::getmedianame(st.name, name, DIR_TEXTURE);
     path(st.name);
     if(tnum==TEX_DIFFUSE)
     {

--- a/src/engine/texture.cpp
+++ b/src/engine/texture.cpp
@@ -2,6 +2,7 @@
 
 #include "engine.h"
 #include "SDL_image.h"
+#include "filesystem.h"
 
 #define FUNCNAME(name) name##1
 #define DEFPIXEL uint OP(r, 0);
@@ -2347,8 +2348,9 @@ Texture *cubemapload(const char *name, bool mipit, bool msg, bool transient)
 {
     if(!hasCM) return NULL;
     string pname;
-    copystring(pname, makerelpath(skyboxdir, name));
+    inexor::filesystem::getmedianame(pname, name, DIR_SKYBOX);
     path(pname);
+
     Texture *t = NULL;
     if(!strchr(pname, '*'))
     {

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -222,15 +222,16 @@ COMMAND(mapcfgname, "");
 /// remove old backup file but keep the file name for the new backup
 /// @param name file name of the new backup
 /// @param backupname file name of the old backup
+/// @return true on success.
 /// @see save_world
-void backup(char *name, char *backupname)
-{   
+bool backup(char *name, char *backupname)
+{
     string backupfile;
     copystring(backupfile, findfile(backupname, "wb"));
     /// remove old backup file
     remove(backupfile);
     /// rename 
-    rename(findfile(name, "wb"), backupfile);
+    return rename(findfile(name, "wb"), backupfile) == 0;
 }
 
 
@@ -996,7 +997,11 @@ bool save_world(const char *mname, bool nolms)
     if(!*mname) mname = game::getclientmap();
     setmapfilenames(*mname ? mname : "untitled");
     /// eventually save backup file
-    if(savebak) backup(ogzname, bakname);
+    if(savebak && !backup(ogzname, bakname))
+    {
+        conoutf(CON_WARN, "could not create backup, skipping saving %s", ogzname);
+        return false;
+    }
     /// open output stream
     stream *f = opengzfile(ogzname, "wb");
     if(!f) 

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -1,9 +1,7 @@
 // worldio.cpp: loading & saving of maps and savegames
 
 #include "engine.h"
-
-SVARP(mediadir, "media");
-SVARP(mapdir, "media/map");
+#include "filesystem.h"
 
 /// remove map postfix (.ogz) from file path/name to get map name
 void cutogz(char *s) 
@@ -17,11 +15,11 @@ void cutogz(char *s)
 /// @param fname folder name
 /// @param realname file name
 /// @param mapname a pointer to where the final map name will be copied (call by reference)
-/// @see cutogz
 void getmapfilename(const char *fname, const char *realname, char *mapname)
 {   
     if(!realname) realname = fname;
-	defformatstring(name) ("%s/%s", mapdir, realname);
+    string name;
+    inexor::filesystem::appendmediadir(name, realname, DIR_MAP);
     cutogz(name);
     copystring(mapname, name, 100);
 }   

--- a/src/fpsgame/bomb.h
+++ b/src/fpsgame/bomb.h
@@ -62,7 +62,9 @@ struct bombclientmode : clientmode
     void drawicon(int icon, float x, float y, float sz) //todo merge with other items
     {
         int bicon = icon - HICON_BOMBRADIUS;
-		settexture(tempformatstring("%s/hud/bomb_items.png", interfacedir));
+        static string iname;
+        inexor::filesystem::appendmediadir(iname, "hud/bomb_items.png", DIR_UI);
+		settexture(iname);
         glBegin(GL_TRIANGLE_STRIP);
         float tsz = 0.25f, tx = tsz*(bicon%4), ty = tsz*(bicon/4);
         glTexCoord2f(tx,     ty);     glVertex2f(x,    y);

--- a/src/fpsgame/client.cpp
+++ b/src/fpsgame/client.cpp
@@ -7,6 +7,7 @@
 ///
 
 #include "game.h"
+#include "filesystem.h"
 
 namespace game
 {
@@ -644,7 +645,7 @@ namespace game
     int gamemode = INT_MAX, nextmode = INT_MAX;
     string clientmap = "";
 
-    /// force server to change map (permissions requred)
+    /// force server to change map (permissions required)
     /// @see startgame
     void changemapserv(const char *name, int mode)
     {
@@ -2133,7 +2134,8 @@ namespace game
                 string oldname;
                 copystring(oldname, getclientmap());
                 defformatstring(mname)("getmap_%d", lastmillis);
-                defformatstring(fname)("%s/%s.ogz", mapdir, mname);
+                string fname;
+                inexor::filesystem::appendmediadir(fname, mname, DIR_MAP, ".ogz");
                 stream *map = openrawfile(path(fname), "wb");
                 if(!map) return;
                 conoutf("received map");
@@ -2225,7 +2227,8 @@ namespace game
         conoutf("sending map...");
         defformatstring(mname)("sendmap_%d", lastmillis);
         save_world(mname, true);
-        defformatstring(fname)("%s/%s.ogz", mapdir, mname);
+        string fname;
+        inexor::filesystem::appendmediadir(fname, mname, DIR_MAP, ".ogz");
         stream *map = openrawfile(path(fname), "rb");
         if(map)
         {

--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -5,6 +5,7 @@
 ///
 
 #include "game.h"
+#include "filesystem.h"
 
 namespace game
 {
@@ -898,7 +899,9 @@ namespace game
 	/// draw (blit) item texture (weapon, flags, armours, quad) on screen at x,y
     void drawicon(int icon, float x, float y, float sz)
     {
-        settexture(tempformatstring("%s/hud/items.png", interfacedir));
+        static string itname;
+        inexor::filesystem::appendmediadir(itname, "hud/items.png", DIR_UI);
+        settexture(itname);
         glBegin(GL_TRIANGLE_STRIP);
         float tsz = 0.25f, tx = tsz*(icon%4), ty = tsz*(icon/4);
         glTexCoord2f(tx,     ty);     glVertex2f(x,    y);

--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -1065,6 +1065,7 @@ namespace game
 	/// render game hud depending on hudplayer's state and "SPECTATOR" in spectator mode
     void gameplayhud(int w, int h)
     {
+        return;
         glPushMatrix();
         glScalef(h/1800.0f, h/1800.0f, 1);
 

--- a/src/fpsgame/pch.cpp
+++ b/src/fpsgame/pch.cpp
@@ -1,2 +1,0 @@
-#include "game.h"
-

--- a/src/fpsgame/waypoint.cpp
+++ b/src/fpsgame/waypoint.cpp
@@ -1,4 +1,7 @@
+/// Bot Movement, according to waypoints (saved within the map in an excluded file).
+
 #include "game.h"
+#include "filesystem.h"
 
 extern selinfo sel;
 
@@ -681,7 +684,7 @@ namespace ai
 
         string mapname;
         getmapfilename(mname, NULL, mapname);
-        formatstring(wptname)("%s/%s.wpt", mapdir, mapname);
+        inexor::filesystem::appendmediadir(wptname, mapname, DIR_MAP, ".wpt");
         path(wptname);
         return true;
     }

--- a/src/shared/command.h
+++ b/src/shared/command.h
@@ -1,8 +1,8 @@
-/// Warning
-/// Do not comment or use the following code in new work!
-/// The whole command and scripting engine is deprecated and will be replaced with javascript (or coffeescript) sooner or later.
-/// -Hanni
+/// Cubescript API
+/// Deprecated.
 
+#ifndef SAUER_COMMAND_H
+#define SAUER_COMMAND_H
 
 /// contains all kind of different script objects
 /// such as commands, variables, macros or idents
@@ -371,3 +371,4 @@ inline void ident::getval(tagval &v) const
 #define ICOMMANDSNAME _icmds_
 #define ICOMMANDS(name, nargs, proto, b) ICOMMANDNS(name, ICOMMANDSNAME, nargs, proto, b)
  
+#endif // SAUER_COMMAND_H

--- a/src/shared/filesystem.cpp
+++ b/src/shared/filesystem.cpp
@@ -45,10 +45,11 @@ namespace inexor {
         /// @warning not threadsafe! (since makerelpath, parentdir and getcurexecdir are not)
         char *getmedianame(char *output, const char *basename, int type, JSON *j)
         {
-            ASSERT(basename != NULL);
-            if(basename[0] == '/') appendmediadir(output, basename, type);
-            else if(j) copystring(output, makerelpath(parentdir(j->currentfile), basename));
-            else copystring(output, makerelpath(getcurexecdir(), basename));
+            ASSERT(basename != NULL && strlen(basename)>=2);
+            if(basename[0] == '/') appendmediadir(output, basename+1, type);
+            else if(j && j->currentfile) copystring(output, makerelpath(parentdir(j->currentfile), basename));
+            else if(!j) copystring(output, makerelpath(getcurexecdir(), basename));
+            else copystring(output, basename);
             return output;
         }
     }

--- a/src/shared/filesystem.cpp
+++ b/src/shared/filesystem.cpp
@@ -14,23 +14,30 @@ SVARP(icondir, "media/interface/icon");
 namespace inexor {
     namespace filesystem {
 
+        /// Returns the specific media dir according to type.
+        const char *getmediadir(int type)
+        {
+            switch(type)
+            {
+            case DIR_MEDIA:     return mediadir;
+            case DIR_MAP:       return mapdir;
+            case DIR_TEXTURE:   return texturedir;
+            case DIR_SKYBOX:    return skyboxdir;
+            case DIR_UI:        return interfacedir;
+            case DIR_ICON:      return icondir;
+            }
+            return NULL;
+        }
+
         /// Append the media directory specified by type to the basename.
         char *appendmediadir(char *output, const char *basename, int type, const char *extension)
         {
-            string dir;
-            switch(type)
-            {
-            case DIR_MEDIA:     copystring(dir, mediadir);          break;
-            case DIR_MAP:       copystring(dir, mapdir);            break;
-            case DIR_TEXTURE:   copystring(dir, texturedir);        break;
-            case DIR_SKYBOX:    copystring(dir, skyboxdir);         break;
-            case DIR_UI:        copystring(dir, interfacedir);      break;
-            case DIR_ICON:      copystring(dir, icondir);           break;
-            }
+
             //size_t dirlen = strlen(dir);
            // if(dirlen >= 2 && (dir[dirlen - 1] == '/' || dir[dirlen - 1] == '\\')) dir[dirlen - 1] = '\0';
 
-            formatstring(output)("%s/%s%s", dir, basename, extension ? extension : "");
+            const char *dir = getmediadir(type);
+            formatstring(output)("%s/%s%s", dir ? dir : "", basename, extension ? extension : "");
             return output;
         }
 

--- a/src/shared/filesystem.cpp
+++ b/src/shared/filesystem.cpp
@@ -1,0 +1,48 @@
+/// string operations on filenames (INCOMPLETE! see e.g. stream.cpp).
+
+#include "filesystem.h"
+
+/// Media paths ///
+
+SVARP(mediadir, "media");
+SVARP(mapdir, "media/map");
+SVARP(texturedir, "media/texture");
+SVARP(skyboxdir, "media/skybox");
+SVARP(interfacedir, "media/interface");
+SVARP(icondir, "media/interface/icon");
+
+namespace inexor {
+    namespace filesystem {
+
+        /// Append the media directory specified by type to the basename.
+        char *appendmediadir(char *output, const char *basename, int type, const char *extension)
+        {
+            string dir;
+            switch(type)
+            {
+            case DIR_MEDIA:     copystring(dir, mediadir);          break;
+            case DIR_MAP:       copystring(dir, mapdir);            break;
+            case DIR_TEXTURE:   copystring(dir, texturedir);        break;
+            case DIR_SKYBOX:    copystring(dir, skyboxdir);         break;
+            case DIR_UI:        copystring(dir, interfacedir);      break;
+            case DIR_ICON:      copystring(dir, icondir);           break;
+            }
+            //size_t dirlen = strlen(dir);
+           // if(dirlen >= 2 && (dir[dirlen - 1] == '/' || dir[dirlen - 1] == '\\')) dir[dirlen - 1] = '\0';
+
+            formatstring(output)("%s/%s%s", dir, basename, extension ? extension : "");
+            return output;
+        }
+
+        /// Get a media name either relative to the current file or the specific media folder according to type.
+        /// @warning not threadsafe! (since makerelpath, parentdir and getcurexecdir are not)
+        char *getmedianame(char *output, const char *basename, int type, JSON *j)
+        {
+            ASSERT(basename != NULL);
+            if(basename[0] == '/') appendmediadir(output, basename, type);
+            else if(j) copystring(output, makerelpath(parentdir(j->currentfile), basename));
+            else copystring(output, makerelpath(getcurexecdir(), basename));
+            return output;
+        }
+    }
+}

--- a/src/shared/filesystem.h
+++ b/src/shared/filesystem.h
@@ -25,6 +25,7 @@ extern char *icondir;
 namespace inexor
 {
     namespace filesystem {
+        extern const char *getmediadir(int type);
         extern char *appendmediadir(char *output, const char *basename, int type, const char *extension = NULL);
         extern char *getmedianame(char *output, const char *basename, int type, JSON *j = NULL);
     }

--- a/src/shared/filesystem.h
+++ b/src/shared/filesystem.h
@@ -1,0 +1,32 @@
+/// string operations on filenames (INCOMPLETE! see e.g. stream.cpp).
+
+#ifndef I_FILESYSTEM_H
+#define I_FILESYSTEM_H
+
+#include "cube.h"
+
+enum {
+    DIR_MEDIA,
+    DIR_MAP,
+    DIR_TEXTURE,
+    DIR_SKYBOX,
+    DIR_UI,
+    DIR_ICON,
+    DIR_NUM
+}; /// media path types.
+
+extern char *mediadir;
+extern char *mapdir;
+extern char *texturedir;
+extern char *skyboxdir;
+extern char *interfacedir;
+extern char *icondir;
+
+namespace inexor
+{
+    namespace filesystem {
+        extern char *appendmediadir(char *output, const char *basename, int type, const char *extension = NULL);
+        extern char *getmedianame(char *output, const char *basename, int type, JSON *j = NULL);
+    }
+}
+#endif // I_FILESYSTEM_H

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -1,9 +1,5 @@
 // the interface the game uses to access the engine
 
-extern char *mediadir;
-extern char *mapdir;
-extern char *interfacedir;
-
 extern int curtime;                     // current frame time
 extern int lastmillis;                  // last time
 extern int elapsedtime;                 // elapsed frame time

--- a/src/shared/stream.cpp
+++ b/src/shared/stream.cpp
@@ -424,8 +424,9 @@ const char *addpackagedir(const char *dir)
     char *filter = pdir;
     for(;;)
     {
-        static int len = strlen(mediadir);
-        filter = strstr(filter, mediadir);
+        const char *meddir = "media"; //wont find any dynamic package dir here anyways (before loading the configs).
+        static int len = strlen(meddir);
+        filter = strstr(filter, meddir);
         if(!filter) break;
         if(filter > pdir && filter[-1] == PATHDIV && filter[len] == PATHDIV) break;
         filter += len;
@@ -1259,4 +1260,3 @@ char *loadfile(const char *fn, size_t *size, bool utf8)
     if(size!=NULL) *size = len;
     return buf;
 }
-

--- a/src/shared/stream.cpp
+++ b/src/shared/stream.cpp
@@ -269,37 +269,39 @@ char *makerelpath(const char *dir, const char *file, const char *prefix, const c
 }
 
 
+/// Modifies the input string to only contain slashes in the direction the platform allows.
+/// Which is \ on windows and / on any other platform.
 char *path(char *s)
 {
     for(char *curpart = s;;)
     {
         char *endpart = strchr(curpart, '&');
         if(endpart) *endpart = '\0';
-        if(curpart[0]=='<')
+        if(curpart[0] == '<')
         {
             char *file = strrchr(curpart, '>');
             if(!file) return s;
-            curpart = file+1;
+            curpart = file + 1;
         }
         for(char *t = curpart; (t = strpbrk(t, "/\\")); *t++ = PATHDIV);
         for(char *prevdir = NULL, *curdir = curpart;;)
         {
-            prevdir = curdir[0]==PATHDIV ? curdir+1 : curdir;
+            prevdir = curdir[0] == PATHDIV ? curdir + 1 : curdir;
             curdir = strchr(prevdir, PATHDIV);
             if(!curdir) break;
-            if(prevdir+1==curdir && prevdir[0]=='.')
+            if(prevdir + 1 == curdir && prevdir[0] == '.')
             {
-                memmove(prevdir, curdir+1, strlen(curdir+1)+1);
+                memmove(prevdir, curdir + 1, strlen(curdir + 1) + 1);
                 curdir = prevdir;
             }
-            else if(curdir[1]=='.' && curdir[2]=='.' && curdir[3]==PATHDIV)
+            else if(curdir[1] == '.' && curdir[2] == '.' && curdir[3] == PATHDIV)
             {
-                if(prevdir+2==curdir && prevdir[0]=='.' && prevdir[1]=='.') continue;
-                memmove(prevdir, curdir+4, strlen(curdir+4)+1);
-                if(prevdir-2 >= curpart && prevdir[-1]==PATHDIV)
+                if(prevdir + 2 == curdir && prevdir[0] == '.' && prevdir[1] == '.') continue;
+                memmove(prevdir, curdir + 4, strlen(curdir + 4) + 1);
+                if(prevdir - 2 >= curpart && prevdir[-1] == PATHDIV)
                 {
                     prevdir -= 2;
-                    while(prevdir-1 >= curpart && prevdir[-1] != PATHDIV) --prevdir;
+                    while(prevdir - 1 >= curpart && prevdir[-1] != PATHDIV) --prevdir;
                 }
                 curdir = prevdir;
             }
@@ -307,13 +309,15 @@ char *path(char *s)
         if(endpart)
         {
             *endpart = '&';
-            curpart = endpart+1;
+            curpart = endpart + 1;
         }
         else break;
     }
     return s;
 }
 
+/// Returns a static string with adapted slashes according to the platforms prefered pathseperator.
+/// @warning not threadsafe!
 char *path(const char *s, bool copy)
 {
     static string tmp;

--- a/src/shared/zip.cpp
+++ b/src/shared/zip.cpp
@@ -1,4 +1,4 @@
-#include "cube.h"
+#include "filesystem.h"
 
 enum
 {
@@ -214,13 +214,14 @@ static bool checkprefix(vector<zipfile> &files, const char *prefix, int prefixle
 
 static void mountzip(ziparchive &arch, vector<zipfile> &files, const char *mountdir, const char *stripdir)
 {
-    string mediadir = "media/";
-    path(mediadir);
+    string medidir;
+    copystring(medidir, mediadir);
+    path(medidir);
     size_t striplen = stripdir ? strlen(stripdir) : 0;
     if(!mountdir && !stripdir) loopv(files)
     {
         zipfile &f = files[i];
-        const char *foundmedia = strstr(f.name, mediadir);
+        const char *foundmedia = strstr(f.name, medidir);
         if(foundmedia)
         {
             if(foundmedia > f.name) 


### PR DESCRIPTION
based on json improvements it fixes a lot of stuff:  
* #139 (bad FPS unless in editmode)

* getcrosshair
* the media system acts way more predictable now:

if you specify something with **`/`** in front of it, it is assumed to be relative to the corresponding dir:
e.g. if you say `texture 0 /philipk/first.jpg` and you have texturedir set to be `media/texture`, it will look for the texture in `media/texture/philipk/first.jpg`

If you do not specify the `/` it will look in the dir relative to the executing file.
e.g. if you have written `texture 0 first.jpg` inside of `media/texture/philipk/package.cfg` (same texture)



(disclaimer: the dynamic filepath system is not fully rewritten: **modeldir** and **sounddir**  are not working that way yet. the same for the font.cfgs)

+ I had to make some interface paths static again since they are pretty bad for fps this way (but i neither want to change it now knowning those parts will disappear anyways)