### PR TITLE
console autocomplete shift-tab to go backwards

### DIFF
--- a/inexor/engine/engine.h
+++ b/inexor/engine/engine.h
@@ -408,7 +408,7 @@ extern int renderconsole(int w, int h, int abovehud);
 extern void conoutf(const char *s, ...) PRINTFARGS(1, 2);
 extern void conoutf(int type, const char *s, ...) PRINTFARGS(2, 3);
 extern void resetcomplete();
-extern void complete(char *s, int maxlen, const char *cmdprefix);
+extern void complete(char *s, int maxlen, const char *cmdprefix, bool backwards);
 const char *getkeyname(int code);
 extern const char *addreleaseaction(char *s);
 extern void writebinds(stream *f);


### PR DESCRIPTION
Tiny feature! Adding the possibility to TAB complete backwards by pressing SHIFT at the same time.

When you go through all the possible commands using TAB and you miss the one you want because you pressed TAB again and can't be bothered to actually type it out SHIFT-TAB comes to the rescue.