### PR TITLE
Fix: Move OpenGL exception defition to engine

### DIFF
--- a/inexor/engine/engine.hpp
+++ b/inexor/engine/engine.hpp
@@ -14,6 +14,9 @@
 #include "inexor/engine/texture.hpp"
 #include "inexor/engine/model.hpp"
 
+#include "inexor/util/InexorException.hpp"
+
+
 extern dynent *player;
 extern physent *camera1;                // special ent that acts as camera, same object as player1 in FPS mode
 
@@ -600,6 +603,9 @@ namespace recorder
     extern void capture(bool overlay = true);
     extern void cleanup();
 }
+
+/// Exception that should be thrown if GL related functionality failed.
+IEXCEPTION(GLException, "OpenGL related functionality failed");
 
 #endif
 

--- a/inexor/ui/cefrenderhandler.cpp
+++ b/inexor/ui/cefrenderhandler.cpp
@@ -1,5 +1,5 @@
 #include "inexor/ui/cefrenderhandler.hpp"
-#include "inexor/util/InexorException.hpp"
+#include "inexor/engine/engine.hpp"
 
 
 // DCHECK on gl errors.
@@ -42,7 +42,7 @@ void InexorCefRenderHandler::Initialize() {
 
     if (0u == texture_id)
     {
-      throw ::inexor::util::GLException("Error: texture id is 0");
+      throw GLException("texture id is 0");
     }
     else
     {
@@ -93,7 +93,7 @@ void InexorCefRenderHandler::Render() {
     // Draw the facets with the texture.
     if (0u == texture_id)
     {
-      throw ::inexor::util::GLException("Error: texture id is 0");
+      throw GLException("texture id is 0");
     }
     else
     {
@@ -179,7 +179,7 @@ void InexorCefRenderHandler::OnPaint(
 
     if (0u == texture_id)
     {
-      throw ::inexor::util::GLException("Error: texture id is 0");
+      throw GLException("texture id is 0");
     }
     else
     {

--- a/inexor/util/InexorException.hpp
+++ b/inexor/util/InexorException.hpp
@@ -102,13 +102,6 @@ public:
 #define IEXCEPTION(name, __what) \
     EXCEPTION(name, ::inexor::util::InexorException, __what)
 
-// ============================================================================
-// === Exception definitions                                                ===
-// ============================================================================
-
-/// Exception that should be thrown if GL related functionality failed.
-IEXCEPTION(GLException, "Error: GL failed");
-
 }
 }
 


### PR DESCRIPTION
The exception definition for OpenGL related errors is now in
enigine/engine.hpp. Also, the error messages were improved.