### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,8 @@
+node { 
+    stage "Checkout project"
+    checkout scm
+
+    stage 'Build'
+    sh '[ -d build ] || mkdir build'
+    sh 'cd build && conan install .. --build=missing && conan build ..'
+}


### PR DESCRIPTION
All repositories and branches containing a [Jenkinsfile](https://jenkins.io/doc/book/pipeline/jenkinsfile/) will be automagically built using our [CI](https://ci.inexor.org)
In addition I've made sure that dependencies are met (and updated that in the wiki respectively).