### PR TITLE
Extend Jenkins Build Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,9 +17,18 @@ node {
 
     stage('Doxygen') {
         tool name: 'doxygen', type: 'hudson.plugins.doxygen.DoxygenInstallation'
+        publishHTML(target: [
+            allowMissing: false,
+            alwaysLinkToLastBuild: false,
+            keepAll: true,
+            reportDir: 'doc/',
+            reportFiles: 'index.html',
+            reportName: 'Inexor Core API Documentation'
+        ])
     }
 
     stage('Archive artifacts') {
+        fingerprint 'bin/inexor,bin/inexor.exe,bin/RPCTreeData-inexor.proto'
         archiveArtifacts artifacts: 'bin/inexor,bin/inexor.exe,bin/RPCTreeData-inexor.proto', fingerprint: true, onlyIfSuccessful: true
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,9 @@ node {
 
     stage('Build with conan') {
         dir('build') {
-            sh 'conan build ..'
+            withEnv(['MAKEFLAGS="-j 2"']) {
+                sh 'conan build ..'
+            }
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,8 @@ node {
     stage 'Build'
     sh '[ -d build ] || mkdir build'
     sh 'cd build && conan install .. --build=missing && conan build ..'
+
+    stage 'Doxygen'
+    tool name: 'doxygen', type: 'hudson.plugins.doxygen.DoxygenInstallation'
+
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,26 @@
 node { 
-    stage "Checkout project"
-    checkout scm
+    stage('Checkout project') {
+        checkout scm
+    }
 
-    stage 'Build'
-    sh '[ -d build ] || mkdir build'
-    sh 'cd build && conan install .. --build=missing && conan build ..'
+    stage('Install and build dependencies') {
+        steps {
+            dir('build') {
+                sh 'conan install .. --build=missing'
+            }
+        }
+    }
 
-    stage 'Doxygen'
-    tool name: 'doxygen', type: 'hudson.plugins.doxygen.DoxygenInstallation'
+    stage('Build with conan') {
+        steps {
+            dir('build') {
+                sh 'conan build ..'
+            }
+        }
+    }
+
+    stage('Doxygen') {
+        tool name: 'doxygen', type: 'hudson.plugins.doxygen.DoxygenInstallation'
+    }
 
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,4 +19,8 @@ node {
         tool name: 'doxygen', type: 'hudson.plugins.doxygen.DoxygenInstallation'
     }
 
+    stage('Archive artifacts') {
+        archiveArtifacts artifacts: 'bin/inexor,bin/inexor.exe,bin/RPCTreeData-inexor.proto', fingerprint: true, onlyIfSuccessful: true
+    }
+
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,18 +4,14 @@ node {
     }
 
     stage('Install and build dependencies') {
-        steps {
-            dir('build') {
-                sh 'conan install .. --build=missing'
-            }
+        dir('build') {
+            sh 'conan install .. --build=missing'
         }
     }
 
     stage('Build with conan') {
-        steps {
-            dir('build') {
-                sh 'conan build ..'
-            }
+        dir('build') {
+            sh 'conan build ..'
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,9 @@ node {
         }
     }
 
-    stage('Doxygen') {
+    stage('Generating API documentation') {
         tool name: 'doxygen', type: 'hudson.plugins.doxygen.DoxygenInstallation'
+        sh 'doxygen doxygen.conf'
         publishHTML(target: [
             allowMissing: false,
             alwaysLinkToLastBuild: false,


### PR DESCRIPTION
* Added generation of the API documentation using Doxygen
* Added archiving artifacts
  * Currently `bin/inexor`, `bin/inexor.exe`, `bin/RPCTreeData-inexor.proto`
  * At a later point we can archive generated `snap packages`, `debian packages` or `MSI installers`
* Splitted building into two separated steps: fetching dependencies and build `Inexor Core` itself
* Use two cores for building `Inexor Core`